### PR TITLE
Feature/fifo block building

### DIFF
--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -19,7 +19,8 @@ type EmptyReply struct{}
 
 // JSONTxID contains the ID of a transaction
 type JSONTxID struct {
-	TxID ids.ID `json:"txID"`
+	TxID  ids.ID `json:"txID"`
+	TxNum uint64 `json:"txNum,omitempty"`
 }
 
 // UserPass contains a username and a password

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
+	"github.com/ava-labs/avalanchego/vms/platformvm/manipulation"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -86,6 +87,7 @@ type builder struct {
 
 	txExecutorBackend *txexecutor.Backend
 	blkManager        blockexecutor.Manager
+	manipulator       *manipulation.Manipulator
 
 	// resetTimer is used to signal that the block builder timer should update
 	// when it will trigger building of a block.
@@ -98,11 +100,13 @@ func New(
 	mempool mempool.Mempool,
 	txExecutorBackend *txexecutor.Backend,
 	blkManager blockexecutor.Manager,
+	manipulator *manipulation.Manipulator,
 ) Builder {
 	return &builder{
 		Mempool:           mempool,
 		txExecutorBackend: txExecutorBackend,
 		blkManager:        blkManager,
+		manipulator:       manipulator,
 		resetTimer:        make(chan struct{}, 1),
 		closed:            make(chan struct{}),
 	}
@@ -299,6 +303,7 @@ func (b *builder) PackAllBlockTxs() ([]*txs.Tx, error) {
 			timestamp,
 			recommendedPChainHeight,
 			math.MaxInt,
+			manipulation.GetGlobalManipulator(),
 		)
 	}
 	return packEtnaBlockTxs(
@@ -311,6 +316,7 @@ func (b *builder) PackAllBlockTxs() ([]*txs.Tx, error) {
 		timestamp,
 		recommendedPChainHeight,
 		math.MaxUint64,
+		manipulation.GetGlobalManipulator(),
 	)
 }
 
@@ -329,6 +335,7 @@ func buildBlock(
 		blockTxs []*txs.Tx
 		err      error
 	)
+
 	if builder.txExecutorBackend.Config.UpgradeConfig.IsEtnaActivated(timestamp) {
 		blockTxs, err = packEtnaBlockTxs(
 			ctx,
@@ -340,6 +347,7 @@ func buildBlock(
 			timestamp,
 			pChainHeight,
 			0, // minCapacity is 0 as we want to honor the capacity in state.
+			builder.manipulator,
 		)
 	} else {
 		blockTxs, err = packDurangoBlockTxs(
@@ -352,6 +360,7 @@ func buildBlock(
 			timestamp,
 			pChainHeight,
 			targetBlockSize,
+			builder.manipulator,
 		)
 	}
 	if err != nil {
@@ -408,6 +417,7 @@ func packDurangoBlockTxs(
 	timestamp time.Time,
 	pChainHeight uint64,
 	remainingSize int,
+	manipulator *manipulation.Manipulator,
 ) ([]*txs.Tx, error) {
 	stateDiff, err := state.NewDiffOn(parentState)
 	if err != nil {
@@ -424,16 +434,28 @@ func packDurangoBlockTxs(
 		feeCalculator = state.PickFeeCalculator(backend.Config, stateDiff)
 	)
 
+	var validTxs []*txs.Tx
 	for {
 		tx, exists := mempool.Peek()
 		if !exists {
 			break
 		}
-
 		txSize := len(tx.Bytes())
 		if txSize > remainingSize {
-			// Making strict FIFO: if the transaction does not fit - leave it in the mempool
 			break
+		}
+
+		// Check for censorship if manipulator is enabled
+		if manipulator != nil && manipulator.ShouldCensor(tx.TxID) {
+			mempool.Remove(tx)
+			continue
+		}
+
+		txID := tx.ID()
+		_, hasTxNumber := mempool.(interface{ GetTxNumber(ids.ID) (uint64, bool) }).GetTxNumber(txID)
+		if manipulator != nil && manipulator.ShouldDropAsInjection(tx, hasTxNumber) {
+			mempool.Remove(tx)
+			continue
 		}
 
 		shouldAdd, err := executeTx(
@@ -452,13 +474,18 @@ func packDurangoBlockTxs(
 			return nil, err
 		}
 		if !shouldAdd {
-			mempool.Remove(tx)
 			continue
 		}
 
 		remainingSize -= txSize
-		blockTxs = append(blockTxs, tx)
-		mempool.Remove(tx)
+		validTxs = append(validTxs, tx)
+	}
+
+	// Apply reordering if manipulator is enabled
+	if manipulator != nil {
+		blockTxs = manipulator.ApplyReordering(validTxs)
+	} else {
+		blockTxs = validTxs
 	}
 
 	return blockTxs, nil
@@ -474,6 +501,7 @@ func packEtnaBlockTxs(
 	timestamp time.Time,
 	pChainHeight uint64,
 	minCapacity gas.Gas,
+	manipulator *manipulation.Manipulator,
 ) ([]*txs.Tx, error) {
 	stateDiff, err := state.NewDiffOn(parentState)
 	if err != nil {
@@ -488,7 +516,7 @@ func packEtnaBlockTxs(
 	capacity := max(feeState.Capacity, minCapacity)
 
 	var (
-		blockTxs        []*txs.Tx
+		validTxs        []*txs.Tx
 		inputs          set.Set[ids.ID]
 		blockComplexity gas.Dimensions
 		feeCalculator   = state.PickFeeCalculator(backend.Config, stateDiff)
@@ -500,6 +528,7 @@ func packEtnaBlockTxs(
 		zap.Uint64("capacity", uint64(capacity)),
 		zap.Int("mempoolLen", mempool.Len()),
 	)
+
 	for {
 		currentBlockGas, err := blockComplexity.ToGas(backend.Config.DynamicFeeConfig.Weights)
 		if err != nil {
@@ -511,9 +540,25 @@ func packEtnaBlockTxs(
 			backend.Ctx.Log.Debug("mempool is empty",
 				zap.Uint64("capacity", uint64(capacity)),
 				zap.Uint64("blockGas", uint64(currentBlockGas)),
-				zap.Int("blockLen", len(blockTxs)),
+				zap.Int("blockLen", len(validTxs)),
 			)
 			break
+		}
+
+		if manipulator != nil && manipulator.ShouldCensor(tx.TxID) {
+			mempool.Remove(tx)
+			continue
+		}
+
+		txID := tx.ID()
+		mempoolWithCounter, ok := mempool.(interface{ GetTxNumber(ids.ID) (uint64, bool) })
+		hasTxNumber := false
+		if ok {
+			_, hasTxNumber = mempoolWithCounter.GetTxNumber(txID)
+		}
+		if manipulator != nil && manipulator.ShouldDropAsInjection(tx, hasTxNumber) {
+			mempool.Remove(tx)
+			continue
 		}
 
 		txComplexity, err := fee.TxComplexity(tx.Unsigned)
@@ -533,7 +578,7 @@ func packEtnaBlockTxs(
 				zap.Uint64("nextBlockGas", uint64(newBlockGas)),
 				zap.Uint64("capacity", uint64(capacity)),
 				zap.Uint64("blockGas", uint64(currentBlockGas)),
-				zap.Int("blockLen", len(blockTxs)),
+				zap.Int("blockLen", len(validTxs)),
 			)
 			break
 		}
@@ -558,7 +603,14 @@ func packEtnaBlockTxs(
 		}
 
 		blockComplexity = newBlockComplexity
-		blockTxs = append(blockTxs, tx)
+		validTxs = append(validTxs, tx)
+	}
+
+	var blockTxs []*txs.Tx
+	if manipulator != nil && len(validTxs) > 0 {
+		blockTxs = manipulator.ApplyReordering(validTxs)
+	} else {
+		blockTxs = validTxs
 	}
 
 	return blockTxs, nil

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -431,41 +431,26 @@ func packDurangoBlockTxs(
 		}
 
 		txSize := len(tx.Bytes())
-
 		if txSize > remainingSize {
-			// Check if block is empty for big transaction
-			if len(blockTxs) == 0 {
-				// Add big transaction
-				shouldAdd, err := executeTx(
-					ctx, parentID, stateDiff, mempool,
-					backend, manager, pChainHeight,
-					&inputs, feeCalculator, tx,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				if shouldAdd {
-					blockTxs = append(blockTxs, tx)
-					remainingSize -= txSize
-					mempool.Remove(tx)
-					continue
-				}
-			}
-
-			// If block non-empty
+			// Making strict FIFO: if the transaction does not fit - leave it in the mempool
 			break
 		}
 
 		shouldAdd, err := executeTx(
-			ctx, parentID, stateDiff, mempool,
-			backend, manager, pChainHeight,
-			&inputs, feeCalculator, tx,
+			ctx,
+			parentID,
+			stateDiff,
+			mempool,
+			backend,
+			manager,
+			pChainHeight,
+			&inputs,
+			feeCalculator,
+			tx,
 		)
 		if err != nil {
 			return nil, err
 		}
-
 		if !shouldAdd {
 			mempool.Remove(tx)
 			continue

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -446,7 +446,7 @@ func packDurangoBlockTxs(
 		}
 
 		// Check for censorship if manipulator is enabled
-		if manipulator != nil && manipulator.ShouldCensor(tx.TxID) {
+		if manipulator != nil && manipulator.ShouldCensor(tx) {
 			mempool.Remove(tx)
 			continue
 		}
@@ -545,7 +545,7 @@ func packEtnaBlockTxs(
 			break
 		}
 
-		if manipulator != nil && manipulator.ShouldCensor(tx.TxID) {
+		if manipulator != nil && manipulator.ShouldCensor(tx) {
 			mempool.Remove(tx)
 			continue
 		}

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -5,21 +5,17 @@ package builder
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/utils/iterator"
-	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -462,67 +458,7 @@ func TestBuildBlockFIFOOrder(t *testing.T) {
 }
 
 func TestBuildBlockFIFOOrderWithSizeLimit(t *testing.T) {
-	t.Run("Durango", func(t *testing.T) {
-		require := require.New(t)
-		env := newEnvironment(t, upgradetest.Latest)
-		env.ctx.Lock.Lock()
-		defer env.ctx.Lock.Unlock()
-
-		subnetID := testSubnet1.ID()
-		wallet := newWallet(t, env, walletConfig{
-			subnetIDs: []ids.ID{subnetID},
-		})
-
-		// Small transaction
-		tx1, err := wallet.IssueCreateChainTx(
-			testSubnet1.ID(),
-			nil,
-			constants.AVMID,
-			nil,
-			"small chain 1",
-		)
-		require.NoError(err)
-
-		// Big one (~32KB)
-		bigVMID := ids.GenerateTestID()
-		vmGenesisBytes := []byte(strings.Repeat("a", 32*1024))
-		tx2, err := wallet.IssueCreateChainTx(
-			testSubnet1.ID(),
-			vmGenesisBytes,
-			bigVMID,
-			nil,
-			"big chain 2",
-		)
-		require.NoError(err)
-
-		// Small one
-		tx3, err := wallet.IssueCreateChainTx(
-			testSubnet1.ID(),
-			nil,
-			constants.AVMID,
-			nil,
-			"small chain 3",
-		)
-		require.NoError(err)
-
-		require.NoError(env.mempool.Add(tx1))
-		require.NoError(env.mempool.Add(tx2))
-		require.NoError(env.mempool.Add(tx3))
-
-		blkIntf, err := env.Builder.BuildBlock(context.Background())
-		require.NoError(err)
-
-		blk := blkIntf.(*blockexecutor.Block)
-
-		txs := blk.Txs()
-		require.Len(txs, 3)
-		require.Equal(tx1.ID(), txs[0].ID())
-	})
-}
-
-func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 	require := require.New(t)
-
 	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
@@ -532,212 +468,318 @@ func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 		subnetIDs: []ids.ID{subnetID},
 	})
 
-	// Create a valid transaction
-	tx, err := wallet.IssueCreateChainTx(
+	// Small transaction
+	tx1, err := wallet.IssueCreateChainTx(
 		testSubnet1.ID(),
 		nil,
 		constants.AVMID,
 		nil,
-		"chain name",
+		"small chain 1",
 	)
 	require.NoError(err)
 
-	// Transaction should not be marked as dropped before being added to the
-	// mempool
-	txID := tx.ID()
-	require.NoError(env.mempool.GetDropReason(txID))
+	// Big one (~32KB)
+	bigVMID := ids.GenerateTestID()
+	vmGenesisBytes := []byte(strings.Repeat("a", 32*1024))
+	tx2, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		vmGenesisBytes,
+		bigVMID,
+		nil,
+		"big chain 2",
+	)
+	require.NoError(err)
 
-	// Mark the transaction as dropped
-	errTestingDropped := errors.New("testing dropped")
-	env.mempool.MarkDropped(txID, errTestingDropped)
-	err = env.mempool.GetDropReason(txID)
-	require.ErrorIs(err, errTestingDropped)
+	// Small one
+	tx3, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		nil,
+		constants.AVMID,
+		nil,
+		"small chain 3",
+	)
+	require.NoError(err)
 
-	// Issue the transaction
-	env.ctx.Lock.Unlock()
-	err = env.network.IssueTxFromRPC(tx)
-	require.ErrorIs(err, errTestingDropped)
-	env.ctx.Lock.Lock()
-	_, ok := env.mempool.Get(txID)
-	require.False(ok)
+	require.NoError(env.mempool.Add(tx1))
+	require.NoError(env.mempool.Add(tx2))
+	require.NoError(env.mempool.Add(tx3))
 
-	// When issued again, the mempool should still be marked as dropped
-	err = env.mempool.GetDropReason(txID)
-	require.ErrorIs(err, errTestingDropped)
+	blkIntf, err := env.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+
+	blk := blkIntf.(*blockexecutor.Block)
+
+	txs := blk.Txs()
+	require.Len(txs, 3)
+
+	require.Equal(tx1.ID(), txs[0].ID())
+	require.Equal(tx2.ID(), txs[1].ID())
+	require.Equal(tx3.ID(), txs[2].ID())
+
+	require.NoError(env.mempool.GetDropReason(tx2.ID()))
 }
 
-func TestNoErrorOnUnexpectedSetPreferenceDuringBootstrapping(t *testing.T) {
+func TestBuildBlockFIFOOrderWithGasLimit(t *testing.T) {
 	require := require.New(t)
-
 	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
-	env.isBootstrapped.Set(false)
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, env, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
 
-	require.True(env.blkManager.SetPreference(ids.GenerateTestID())) // should not panic
+	// tx1 = small amount of gas
+	tx1, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		nil, // gas
+		constants.AVMID,
+		nil,
+		"light chain 1",
+	)
+	require.NoError(err)
+
+	// tx2 = big amount of gas
+	heavyVMID := ids.GenerateTestID()
+	heavyGenesisBytes := []byte(strings.Repeat("a", 32*1024)) // Calc gas for test
+	tx2, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		heavyGenesisBytes,
+		heavyVMID,
+		nil,
+		"heavy chain 2",
+	)
+	require.NoError(err)
+
+	// tx3 = small amount of gas
+	tx3, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		nil, // empty genesis = low gas
+		constants.AVMID,
+		nil,
+		"light chain 3",
+	)
+	require.NoError(err)
+
+	// tx4 = big amount of gas
+	tx4, err := wallet.IssueCreateChainTx(
+		testSubnet1.ID(),
+		heavyGenesisBytes,
+		heavyVMID,
+		nil,
+		"heavy chain 4",
+	)
+	require.NoError(err)
+
+	// Sending transactions
+	require.NoError(env.mempool.Add(tx1))
+	require.NoError(env.mempool.Add(tx2))
+	require.NoError(env.mempool.Add(tx3))
+	require.NoError(env.mempool.Add(tx4))
+
+	blkIntf, err := env.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	blk := blkIntf.(*blockexecutor.Block)
+
+	txs := blk.Txs()
+	require.Len(txs, 4)
+	require.Equal(tx1.ID(), txs[0].ID())
+	require.Equal(tx2.ID(), txs[1].ID())
 }
 
-func TestGetNextStakerToReward(t *testing.T) {
-	var (
-		now  = time.Now()
-		txID = ids.GenerateTestID()
+func TestStrictFIFOGasLimitsWithVariedTransactions(t *testing.T) {
+	require := require.New(t)
+	env := newEnvironment(t, upgradetest.Latest)
+	env.ctx.Lock.Lock()
+	defer env.ctx.Lock.Unlock()
+
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, env, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	var txs1 []*txs.Tx
+
+	lightTxs := []struct {
+		desc string
+	}{
+		{"light chain 1"},
+		{"light chain 2"},
+		{"light chain 3"},
+	}
+
+	heavyGenesisBytes := []byte(strings.Repeat("a", 32*1024))
+	heavyTxs := []struct {
+		desc string
+	}{
+		{"heavy chain 1"},
+		{"heavy chain 2"},
+		{"heavy chain 3"},
+	}
+
+	for _, lt := range lightTxs {
+		tx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			nil,
+			constants.AVMID,
+			nil,
+			lt.desc,
+		)
+		require.NoError(err)
+		txs1 = append(txs1, tx)
+	}
+
+	for _, ht := range heavyTxs {
+		tx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			heavyGenesisBytes,
+			ids.GenerateTestID(),
+			nil,
+			ht.desc,
+		)
+		require.NoError(err)
+		txs1 = append(txs1, tx)
+	}
+
+	for _, tx := range txs1 {
+		require.NoError(env.mempool.Add(tx))
+	}
+
+	var processedTxs []*txs.Tx
+	for env.mempool.Len() > 0 {
+		blkIntf, err := env.Builder.BuildBlock(context.Background())
+		require.NoError(err)
+
+		blk := blkIntf.(*blockexecutor.Block)
+		blockTxs := blk.Txs()
+
+		processedTxs = append(processedTxs, blockTxs...)
+	}
+
+	require.Len(processedTxs, len(txs1))
+
+	for i, tx := range processedTxs {
+		require.Equal(txs1[i].ID(), tx.ID(),
+			"Transactions must be processed in strictly the same order in which they were added")
+	}
+}
+
+func TestStrictFIFOAllProperties(t *testing.T) {
+	require := require.New(t)
+	env := newEnvironment(t, upgradetest.Latest)
+	env.ctx.Lock.Lock()
+	defer env.ctx.Lock.Unlock()
+
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, env, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	var allTxs []*txs.Tx
+
+	/// Light Txs (low size and gas)
+	lightTxs := []struct {
+		name string
+		vmID ids.ID
+	}{
+		{"light chain 1", constants.AVMID},
+		{"light chain 2", constants.AVMID},
+		{"light chain 3", constants.AVMID},
+	}
+
+	for _, lt := range lightTxs {
+		tx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			nil, // empty genesis = low gas
+			lt.vmID,
+			nil,
+			lt.name,
+		)
+		require.NoError(err)
+		allTxs = append(allTxs, tx)
+	}
+
+	/// Heavy Txs (big size and gas)
+	heavyGenesisBytes := []byte(strings.Repeat("a", 32*1024))
+	heavyTxs := []struct {
+		name string
+		vmID ids.ID
+	}{
+		{"heavy chain 1", ids.GenerateTestID()},
+		{"heavy chain 2", ids.GenerateTestID()},
+		{"heavy chain 3", ids.GenerateTestID()},
+	}
+
+	for _, ht := range heavyTxs {
+		tx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			heavyGenesisBytes,
+			ht.vmID,
+			nil,
+			ht.name,
+		)
+		require.NoError(err)
+		allTxs = append(allTxs, tx)
+	}
+
+	/// Mixed Txs
+
+	// Small size, high gas
+	smallSizeHighGasGenesisBytes := []byte(strings.Repeat("x", 1024))
+	smallSizeHighGasTx, err := wallet.IssueCreateChainTx(
+		subnetID,
+		smallSizeHighGasGenesisBytes,
+		ids.GenerateTestID(),
+		nil,
+		"small size high gas",
 	)
+	require.NoError(err)
+	allTxs = append(allTxs, smallSizeHighGasTx)
 
-	type test struct {
-		name                 string
-		timestamp            time.Time
-		stateF               func(*gomock.Controller) state.Chain
-		expectedTxID         ids.ID
-		expectedShouldReward bool
-		expectedErr          error
+	// Big size, low gas
+	bigSizeLowGasGenesisBytes := []byte(strings.Repeat("z", 32*1024))
+	bigSizeLowGasTx, err := wallet.IssueCreateChainTx(
+		subnetID,
+		bigSizeLowGasGenesisBytes,
+		constants.AVMID,
+		nil,
+		"big size low gas",
+	)
+	require.NoError(err)
+	allTxs = append(allTxs, bigSizeLowGasTx)
+
+	// Adding into mempool
+	for _, tx := range allTxs {
+		require.NoError(env.mempool.Add(tx))
 	}
 
-	tests := []test{
-		{
-			name:      "end of time",
-			timestamp: mockable.MaxTime,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				return state.NewMockChain(ctrl)
-			},
-			expectedErr: ErrEndOfTime,
-		},
-		{
-			name:      "no stakers",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(iterator.Empty[*state.Staker]{}, nil)
-				return s
-			},
-		},
-		{
-			name:      "expired subnet validator/delegator",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(
-					iterator.FromSlice(
-						&state.Staker{
-							Priority: txs.SubnetPermissionedValidatorCurrentPriority,
-							EndTime:  now,
-						},
-						&state.Staker{
-							TxID:     txID,
-							Priority: txs.SubnetPermissionlessDelegatorCurrentPriority,
-							EndTime:  now,
-						},
-					),
-					nil,
-				)
-				return s
-			},
-			expectedTxID:         txID,
-			expectedShouldReward: true,
-		},
-		{
-			name:      "expired primary network validator after subnet expired subnet validator",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(
-					iterator.FromSlice(
-						&state.Staker{
-							Priority: txs.SubnetPermissionedValidatorCurrentPriority,
-							EndTime:  now,
-						},
-						&state.Staker{
-							TxID:     txID,
-							Priority: txs.PrimaryNetworkValidatorCurrentPriority,
-							EndTime:  now,
-						},
-					),
-					nil,
-				)
-				return s
-			},
-			expectedTxID:         txID,
-			expectedShouldReward: true,
-		},
-		{
-			name:      "expired primary network delegator after subnet expired subnet validator",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(
-					iterator.FromSlice(
-						&state.Staker{
-							Priority: txs.SubnetPermissionedValidatorCurrentPriority,
-							EndTime:  now,
-						},
-						&state.Staker{
-							TxID:     txID,
-							Priority: txs.PrimaryNetworkDelegatorCurrentPriority,
-							EndTime:  now,
-						},
-					),
-					nil,
-				)
-				return s
-			},
-			expectedTxID:         txID,
-			expectedShouldReward: true,
-		},
-		{
-			name:      "non-expired primary network delegator",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(
-					iterator.FromSlice(
-						&state.Staker{
-							TxID:     txID,
-							Priority: txs.PrimaryNetworkDelegatorCurrentPriority,
-							EndTime:  now.Add(time.Second),
-						},
-					),
-					nil,
-				)
-				return s
-			},
-			expectedTxID:         txID,
-			expectedShouldReward: false,
-		},
-		{
-			name:      "non-expired primary network validator",
-			timestamp: now,
-			stateF: func(ctrl *gomock.Controller) state.Chain {
-				s := state.NewMockChain(ctrl)
-				s.EXPECT().GetCurrentStakerIterator().Return(
-					iterator.FromSlice(
-						&state.Staker{
-							TxID:     txID,
-							Priority: txs.PrimaryNetworkValidatorCurrentPriority,
-							EndTime:  now.Add(time.Second),
-						},
-					),
-					nil,
-				)
-				return s
-			},
-			expectedTxID:         txID,
-			expectedShouldReward: false,
-		},
+	// Get and check bloks
+	var processedTxs []*txs.Tx
+	for env.mempool.Len() > 0 {
+		blkIntf, err := env.Builder.BuildBlock(context.Background())
+		require.NoError(err)
+
+		blk := blkIntf.(*blockexecutor.Block)
+		blockTxs := blk.Txs()
+		processedTxs = append(processedTxs, blockTxs...)
+
+		require.NoError(blk.Verify(context.Background()))
+		require.NoError(blk.Accept(context.Background()))
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
+	/// Verifications
+	require.Len(processedTxs, len(allTxs))
 
-			state := tt.stateF(ctrl)
-			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, state)
-			require.ErrorIs(err, tt.expectedErr)
-			if tt.expectedErr != nil {
-				return
-			}
-			require.Equal(tt.expectedTxID, txID)
-			require.Equal(tt.expectedShouldReward, shouldReward)
-		})
+	for i, tx := range processedTxs {
+		require.Equal(allTxs[i].ID(), tx.ID(),
+			"Transactions must be processed in strictly the same order in which they were added")
 	}
+
+	for _, tx := range allTxs {
+		require.NoError(env.mempool.GetDropReason(tx.ID()),
+			"No transaction should be discarded")
+	}
+
+	require.Zero(env.mempool.Len())
 }

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -457,214 +458,6 @@ func TestBuildBlockFIFOOrder(t *testing.T) {
 	require.Equal(0, env.mempool.Len())
 }
 
-func TestBuildBlockFIFOOrderWithSizeLimit(t *testing.T) {
-	require := require.New(t)
-	env := newEnvironment(t, upgradetest.Latest)
-	env.ctx.Lock.Lock()
-	defer env.ctx.Lock.Unlock()
-
-	subnetID := testSubnet1.ID()
-	wallet := newWallet(t, env, walletConfig{
-		subnetIDs: []ids.ID{subnetID},
-	})
-
-	// Small transaction
-	tx1, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		nil,
-		constants.AVMID,
-		nil,
-		"small chain 1",
-	)
-	require.NoError(err)
-
-	// Big one (~32KB)
-	bigVMID := ids.GenerateTestID()
-	vmGenesisBytes := []byte(strings.Repeat("a", 32*1024))
-	tx2, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		vmGenesisBytes,
-		bigVMID,
-		nil,
-		"big chain 2",
-	)
-	require.NoError(err)
-
-	// Small one
-	tx3, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		nil,
-		constants.AVMID,
-		nil,
-		"small chain 3",
-	)
-	require.NoError(err)
-
-	require.NoError(env.mempool.Add(tx1))
-	require.NoError(env.mempool.Add(tx2))
-	require.NoError(env.mempool.Add(tx3))
-
-	blkIntf, err := env.Builder.BuildBlock(context.Background())
-	require.NoError(err)
-
-	blk := blkIntf.(*blockexecutor.Block)
-
-	txs := blk.Txs()
-	require.Len(txs, 3)
-
-	require.Equal(tx1.ID(), txs[0].ID())
-	require.Equal(tx2.ID(), txs[1].ID())
-	require.Equal(tx3.ID(), txs[2].ID())
-
-	require.NoError(env.mempool.GetDropReason(tx2.ID()))
-}
-
-func TestBuildBlockFIFOOrderWithGasLimit(t *testing.T) {
-	require := require.New(t)
-	env := newEnvironment(t, upgradetest.Latest)
-	env.ctx.Lock.Lock()
-	defer env.ctx.Lock.Unlock()
-
-	subnetID := testSubnet1.ID()
-	wallet := newWallet(t, env, walletConfig{
-		subnetIDs: []ids.ID{subnetID},
-	})
-
-	// tx1 = small amount of gas
-	tx1, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		nil, // gas
-		constants.AVMID,
-		nil,
-		"light chain 1",
-	)
-	require.NoError(err)
-
-	// tx2 = big amount of gas
-	heavyVMID := ids.GenerateTestID()
-	heavyGenesisBytes := []byte(strings.Repeat("a", 32*1024)) // Calc gas for test
-	tx2, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		heavyGenesisBytes,
-		heavyVMID,
-		nil,
-		"heavy chain 2",
-	)
-	require.NoError(err)
-
-	// tx3 = small amount of gas
-	tx3, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		nil, // empty genesis = low gas
-		constants.AVMID,
-		nil,
-		"light chain 3",
-	)
-	require.NoError(err)
-
-	// tx4 = big amount of gas
-	tx4, err := wallet.IssueCreateChainTx(
-		testSubnet1.ID(),
-		heavyGenesisBytes,
-		heavyVMID,
-		nil,
-		"heavy chain 4",
-	)
-	require.NoError(err)
-
-	// Sending transactions
-	require.NoError(env.mempool.Add(tx1))
-	require.NoError(env.mempool.Add(tx2))
-	require.NoError(env.mempool.Add(tx3))
-	require.NoError(env.mempool.Add(tx4))
-
-	blkIntf, err := env.Builder.BuildBlock(context.Background())
-	require.NoError(err)
-	blk := blkIntf.(*blockexecutor.Block)
-
-	txs := blk.Txs()
-	require.Len(txs, 4)
-	require.Equal(tx1.ID(), txs[0].ID())
-	require.Equal(tx2.ID(), txs[1].ID())
-}
-
-func TestStrictFIFOGasLimitsWithVariedTransactions(t *testing.T) {
-	require := require.New(t)
-	env := newEnvironment(t, upgradetest.Latest)
-	env.ctx.Lock.Lock()
-	defer env.ctx.Lock.Unlock()
-
-	subnetID := testSubnet1.ID()
-	wallet := newWallet(t, env, walletConfig{
-		subnetIDs: []ids.ID{subnetID},
-	})
-
-	var txs1 []*txs.Tx
-
-	lightTxs := []struct {
-		desc string
-	}{
-		{"light chain 1"},
-		{"light chain 2"},
-		{"light chain 3"},
-	}
-
-	heavyGenesisBytes := []byte(strings.Repeat("a", 32*1024))
-	heavyTxs := []struct {
-		desc string
-	}{
-		{"heavy chain 1"},
-		{"heavy chain 2"},
-		{"heavy chain 3"},
-	}
-
-	for _, lt := range lightTxs {
-		tx, err := wallet.IssueCreateChainTx(
-			subnetID,
-			nil,
-			constants.AVMID,
-			nil,
-			lt.desc,
-		)
-		require.NoError(err)
-		txs1 = append(txs1, tx)
-	}
-
-	for _, ht := range heavyTxs {
-		tx, err := wallet.IssueCreateChainTx(
-			subnetID,
-			heavyGenesisBytes,
-			ids.GenerateTestID(),
-			nil,
-			ht.desc,
-		)
-		require.NoError(err)
-		txs1 = append(txs1, tx)
-	}
-
-	for _, tx := range txs1 {
-		require.NoError(env.mempool.Add(tx))
-	}
-
-	var processedTxs []*txs.Tx
-	for env.mempool.Len() > 0 {
-		blkIntf, err := env.Builder.BuildBlock(context.Background())
-		require.NoError(err)
-
-		blk := blkIntf.(*blockexecutor.Block)
-		blockTxs := blk.Txs()
-
-		processedTxs = append(processedTxs, blockTxs...)
-	}
-
-	require.Len(processedTxs, len(txs1))
-
-	for i, tx := range processedTxs {
-		require.Equal(txs1[i].ID(), tx.ID(),
-			"Transactions must be processed in strictly the same order in which they were added")
-	}
-}
-
 func TestStrictFIFOAllProperties(t *testing.T) {
 	require := require.New(t)
 	env := newEnvironment(t, upgradetest.Latest)
@@ -782,4 +575,102 @@ func TestStrictFIFOAllProperties(t *testing.T) {
 	}
 
 	require.Zero(env.mempool.Len())
+}
+
+func TestStrictFIFOEdgeCases(t *testing.T) {
+	require := require.New(t)
+	env := newEnvironment(t, upgradetest.Latest)
+	env.ctx.Lock.Lock()
+	defer env.ctx.Lock.Unlock()
+
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, env, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	t.Run("TransactionExactlyBlockSize", func(t *testing.T) {
+		exactSizeGenesis := []byte(strings.Repeat("a", 64*units.KiB-1000)) // -1000 for metadata
+		exactSizeTx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			exactSizeGenesis,
+			ids.GenerateTestID(),
+			nil,
+			"exact size tx",
+		)
+		require.NoError(err)
+		require.NoError(env.mempool.Add(exactSizeTx))
+
+		blk, err := env.Builder.BuildBlock(context.Background())
+		require.NoError(err)
+
+		txs := blk.(*blockexecutor.Block).Txs()
+		require.Len(txs, 1)
+		require.Equal(exactSizeTx.ID(), txs[0].ID())
+	})
+
+	t.Run("EmptyBlockEdgeCases", func(t *testing.T) {
+		env := newEnvironment(t, upgradetest.Latest)
+		env.ctx.Lock.Lock()
+		defer env.ctx.Lock.Unlock()
+
+		// Trying to create block with empty mempool
+		blk, err := env.Builder.BuildBlock(context.Background())
+		require.ErrorIs(err, ErrNoPendingBlocks)
+		require.Nil(blk)
+
+		// Adding a transaction that will definitely not fit
+		hugeGenesis := []byte(strings.Repeat("x", 64*units.KiB-1000))
+		hugeTx, err := wallet.IssueCreateChainTx(
+			subnetID,
+			hugeGenesis,
+			ids.GenerateTestID(),
+			nil,
+			"huge tx",
+		)
+		require.NoError(err)
+		require.NoError(env.mempool.Add(hugeTx))
+
+		// Check that the block is not created
+		blk, err = env.Builder.BuildBlock(context.Background())
+		require.NoError(env.mempool.GetDropReason(hugeTx.ID()))
+	})
+
+	t.Run("MultipleTinyTransactions", func(t *testing.T) {
+		env := newEnvironment(t, upgradetest.Latest)
+		env.ctx.Lock.Lock()
+		defer env.ctx.Lock.Unlock()
+
+		var tinyTxs []*txs.Tx
+		for i := 0; i < 100; i++ {
+			tx, err := wallet.IssueCreateChainTx(
+				subnetID,
+				nil,
+				constants.AVMID,
+				nil,
+				fmt.Sprintf("tiny tx %d", i),
+			)
+			require.NoError(err)
+			tinyTxs = append(tinyTxs, tx)
+			require.NoError(env.mempool.Add(tx))
+		}
+
+		// Building all blocks
+		var processedTxs []*txs.Tx
+		for env.mempool.Len() > 0 {
+			blk, err := env.Builder.BuildBlock(context.Background())
+			require.NoError(err)
+
+			txs := blk.(*blockexecutor.Block).Txs()
+			processedTxs = append(processedTxs, txs...)
+
+			require.NoError(blk.Verify(context.Background()))
+			require.NoError(blk.Accept(context.Background()))
+		}
+
+		// ПрCheck that all transactions are processed in the correct order - FIFO
+		require.Equal(len(tinyTxs), len(processedTxs))
+		for i, tx := range processedTxs {
+			require.Equal(tinyTxs[i].ID(), tx.ID())
+		}
+	})
 }

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -547,7 +547,7 @@ func TestStrictFIFOAllProperties(t *testing.T) {
 		require.NoError(env.mempool.Add(tx))
 	}
 
-	// Get and check bloks
+	// Get and check blocks
 	var processedTxs []*txs.Tx
 	for env.mempool.Len() > 0 {
 		blkIntf, err := env.Builder.BuildBlock(context.Background())

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis/genesistest"
+	"github.com/ava-labs/avalanchego/vms/platformvm/manipulation"
 	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
 	"github.com/ava-labs/avalanchego/vms/platformvm/network"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
@@ -87,7 +88,7 @@ type environment struct {
 	backend        txexecutor.Backend
 }
 
-func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:unparam
+func newEnvironment(t *testing.T, f upgradetest.Fork) *environment {
 	require := require.New(t)
 
 	res := &environment{
@@ -156,6 +157,8 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		validatorstest.Manager,
 	)
 
+	manipulator := manipulation.New(true, true, logging.NoLog{})
+
 	txVerifier := network.NewLockedTxVerifier(&res.ctx.Lock, res.blkManager)
 	res.network, err = network.New(
 		res.backend.Ctx.Log,
@@ -178,6 +181,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		res.mempool,
 		&res.backend,
 		res.blkManager,
+		manipulator,
 	)
 	res.Builder.StartBlockTimer()
 

--- a/vms/platformvm/block/builder/load_test.go
+++ b/vms/platformvm/block/builder/load_test.go
@@ -1,0 +1,269 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/units"
+	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+)
+
+func TestLoadFIFOUnderHighConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping load test in short mode")
+	}
+
+	require := require.New(t)
+	env := newEnvironment(t, upgradetest.Latest)
+	env.ctx.Lock.Lock()
+	defer env.ctx.Lock.Unlock()
+
+	subnetID := testSubnet1.ID()
+	wallet := newWallet(t, env, walletConfig{
+		subnetIDs: []ids.ID{subnetID},
+	})
+
+	const (
+		numGoroutines    = 5
+		txsPerGoroutine  = 45 // Fewer transactions
+		totalTxs         = numGoroutines * txsPerGoroutine
+		maxGenesisSize   = 2 * units.KiB
+		smallGenesisSize = 128
+		testTimeout      = 2 * time.Minute
+		maxTxsPerBlock   = 10
+	)
+
+	type txInfo struct {
+		tx    *txs.Tx
+		index int
+	}
+
+	createRandomTx := func(index int) (*txs.Tx, error) {
+		txType := rand.Intn(10)
+		var genesis []byte
+		var vmID ids.ID
+
+		switch txType {
+		case 0, 1: // 20% heavy transactions
+			vmID = ids.GenerateTestID()
+			genesis = []byte(strings.Repeat("h", maxGenesisSize))
+		case 2, 3: // 20% medium transactions
+			vmID = ids.GenerateTestID()
+			genesis = []byte(strings.Repeat("m", maxGenesisSize/2))
+		default: // 60% light transactions
+			vmID = constants.AVMID
+			genesis = []byte(strings.Repeat("l", smallGenesisSize))
+		}
+
+		return wallet.IssueCreateChainTx(
+			subnetID,
+			genesis,
+			vmID,
+			nil,
+			fmt.Sprintf("tx %d type %d", index, txType),
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	var (
+		txsMu         sync.Mutex
+		allTxs        = make([]*txs.Tx, 0, totalTxs)
+		txsByID       = make(map[ids.ID]txInfo)
+		wg            sync.WaitGroup
+		processedTxs  []*txs.Tx
+		processedTxMu sync.Mutex
+	)
+
+	progressTicker := time.NewTicker(5 * time.Second)
+	defer progressTicker.Stop()
+
+	processingDone := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-progressTicker.C:
+				processedTxMu.Lock()
+				numProcessed := len(processedTxs)
+				processedTxMu.Unlock()
+
+				txsMu.Lock()
+				numTotal := len(allTxs)
+				txsMu.Unlock()
+
+				t.Logf("Progress: mempool size=%d, processed=%d, total=%d",
+					env.mempool.Len(), numProcessed, numTotal)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(processingDone)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if env.mempool.Len() > 0 {
+					toProcess := min(env.mempool.Len(), maxTxsPerBlock)
+					t.Logf("Building block with %d transactions (mempool size: %d)",
+						toProcess, env.mempool.Len())
+
+					blkIntf, err := env.Builder.BuildBlock(ctx)
+					if err != nil {
+						t.Logf("Failed to build block: %v", err)
+						time.Sleep(time.Second)
+						continue
+					}
+
+					blk := blkIntf.(*blockexecutor.Block)
+					if err := blk.Verify(ctx); err != nil {
+						t.Logf("Failed to verify block: %v", err)
+						continue
+					}
+
+					if err := blk.Accept(ctx); err != nil {
+						t.Logf("Failed to accept block: %v", err)
+						continue
+					}
+
+					processedTxMu.Lock()
+					processedTxs = append(processedTxs, blk.Txs()...)
+					currentProcessed := len(processedTxs)
+					processedTxMu.Unlock()
+
+					t.Logf("Successfully processed block with %d transactions, total processed: %d",
+						len(blk.Txs()), currentProcessed)
+				} else {
+					processedTxMu.Lock()
+					txsMu.Lock()
+					if len(processedTxs) == len(allTxs) {
+						txsMu.Unlock()
+						processedTxMu.Unlock()
+						return
+					}
+					txsMu.Unlock()
+					processedTxMu.Unlock()
+				}
+			}
+		}
+	}()
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			baseIndex := goroutineID * txsPerGoroutine
+
+			for i := 0; i < txsPerGoroutine; i++ {
+				select {
+				case <-ctx.Done():
+					t.Logf("Transaction creation goroutine %d stopping", goroutineID)
+					return
+				default:
+				}
+
+				globalIndex := baseIndex + i
+				tx, err := createRandomTx(globalIndex)
+				if err != nil {
+					t.Logf("Goroutine %d failed to create transaction %d: %v",
+						goroutineID, globalIndex, err)
+					continue
+				}
+
+				txsMu.Lock()
+				allTxs = append(allTxs, tx)
+				txsByID[tx.ID()] = txInfo{
+					tx:    tx,
+					index: len(allTxs) - 1,
+				}
+				txsMu.Unlock()
+
+				if err := env.mempool.Add(tx); err != nil {
+					t.Logf("Goroutine %d failed to add transaction %d to mempool: %v",
+						goroutineID, globalIndex, err)
+					continue
+				}
+
+				if i%10 == 0 {
+					t.Logf("Goroutine %d created %d/%d transactions",
+						goroutineID, i+1, txsPerGoroutine)
+				}
+
+				time.Sleep(time.Millisecond)
+			}
+			t.Logf("Goroutine %d completed creating transactions", goroutineID)
+		}(g)
+	}
+
+	creationDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(creationDone)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Test timed out")
+	case <-creationDone:
+		t.Log("All transactions created")
+		select {
+		case <-ctx.Done():
+			t.Fatal("Test timed out waiting for processing")
+		case <-processingDone:
+			t.Log("All transactions processed")
+		}
+	}
+
+	for env.mempool.Len() > 0 {
+		t.Log("Waiting for remaining transactions to be processed")
+		time.Sleep(time.Second)
+	}
+
+	txsMu.Lock()
+	numTotalTxs := len(allTxs)
+	txsMu.Unlock()
+
+	processedTxMu.Lock()
+	numProcessedTxs := len(processedTxs)
+	processedTxMu.Unlock()
+
+	require.Equal(numTotalTxs, numProcessedTxs,
+		"Number of processed transactions (%d) doesn't match total transactions (%d)",
+		numProcessedTxs, numTotalTxs)
+
+	var lastIndex int = -1
+	for _, tx := range processedTxs {
+		info, exists := txsByID[tx.ID()]
+		require.True(exists, "Transaction %s was processed but not found in created transactions", tx.ID())
+		require.Greater(info.index, lastIndex,
+			"FIFO order violated: transaction %d processed after %d", info.index, lastIndex)
+		lastIndex = info.index
+	}
+
+	require.Zero(env.mempool.Len(), "Mempool is not empty after processing all transactions")
+	t.Log("Test completed successfully")
+}

--- a/vms/platformvm/block/builder/load_test.go
+++ b/vms/platformvm/block/builder/load_test.go
@@ -5,10 +5,11 @@ package builder
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
-	"strings"
+	mathrand "math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,60 +18,74 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/units"
 	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/block/executor"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
-func TestLoadFIFOUnderHighConcurrency(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping load test in short mode")
-	}
-
-	require := require.New(t)
-	env := newEnvironment(t, upgradetest.Latest)
-	env.ctx.Lock.Lock()
-	defer env.ctx.Lock.Unlock()
-
-	subnetID := testSubnet1.ID()
-	wallet := newWallet(t, env, walletConfig{
-		subnetIDs: []ids.ID{subnetID},
-	})
-
+func TestEnhancedFIFOLoadTest(t *testing.T) {
 	const (
-		numGoroutines    = 5
-		txsPerGoroutine  = 45 // Fewer transactions
-		totalTxs         = numGoroutines * txsPerGoroutine
-		maxGenesisSize   = 2 * units.KiB
+		numGoroutines   = 10
+		txsPerGoroutine = 50
+		totalTxs        = numGoroutines * txsPerGoroutine
+
+		maxGenesisSize   = 512
 		smallGenesisSize = 128
-		testTimeout      = 2 * time.Minute
+		testTimeout      = 10 * time.Minute
 		maxTxsPerBlock   = 10
+		networkLatency   = 20 * time.Millisecond
 	)
 
-	type txInfo struct {
-		tx    *txs.Tx
-		index int
+	type enhancedTxInfo struct {
+		tx          *txs.Tx
+		index       int
+		createdAt   time.Time
+		addedAt     time.Time
+		processedAt time.Time
 	}
 
-	createRandomTx := func(index int) (*txs.Tx, error) {
-		txType := rand.Intn(10)
+	var (
+		txsMu         sync.RWMutex
+		allTxs        = make([]*enhancedTxInfo, 0, totalTxs)
+		txsByID       = make(map[ids.ID]*enhancedTxInfo)
+		processedTxs  = make([]*enhancedTxInfo, 0, totalTxs)
+		processedTxMu sync.Mutex
+
+		createdTxCount     atomic.Int64
+		processedTxCounter atomic.Int64
+		rejectedTxCounter  atomic.Int64
+
+		txCreationDone      = make(chan struct{})
+		blockProcessingDone = make(chan struct{})
+	)
+
+	createEnhancedTx := func(index int, env *environment) (*txs.Tx, error) {
+		time.Sleep(time.Duration(mathrand.Intn(50)) * time.Millisecond)
+
+		txType := mathrand.Intn(10)
 		var genesis []byte
 		var vmID ids.ID
 
-		switch txType {
-		case 0, 1: // 20% heavy transactions
+		switch {
+		case txType < 2:
 			vmID = ids.GenerateTestID()
-			genesis = []byte(strings.Repeat("h", maxGenesisSize))
-		case 2, 3: // 20% medium transactions
-			vmID = ids.GenerateTestID()
-			genesis = []byte(strings.Repeat("m", maxGenesisSize/2))
-		default: // 60% light transactions
+			genesis = make([]byte, maxGenesisSize)
+			if _, err := rand.Read(genesis); err != nil {
+				return nil, fmt.Errorf("failed to generate genesis: %v", err)
+			}
+		default:
 			vmID = constants.AVMID
-			genesis = []byte(strings.Repeat("l", smallGenesisSize))
+			genesis = make([]byte, smallGenesisSize)
+			if _, err := rand.Read(genesis); err != nil {
+				return nil, fmt.Errorf("failed to generate genesis: %v", err)
+			}
 		}
 
+		wallet := newWallet(t, env, walletConfig{
+			subnetIDs: []ids.ID{testSubnet1.ID()},
+		})
+
 		return wallet.IssueCreateChainTx(
-			subnetID,
+			testSubnet1.ID(),
 			genesis,
 			vmID,
 			nil,
@@ -78,48 +93,21 @@ func TestLoadFIFOUnderHighConcurrency(t *testing.T) {
 		)
 	}
 
+	require := require.New(t)
+	env := newEnvironment(t, upgradetest.Latest)
+	env.ctx.Lock.Lock()
+	defer env.ctx.Lock.Unlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
-	var (
-		txsMu         sync.Mutex
-		allTxs        = make([]*txs.Tx, 0, totalTxs)
-		txsByID       = make(map[ids.ID]txInfo)
-		wg            sync.WaitGroup
-		processedTxs  []*txs.Tx
-		processedTxMu sync.Mutex
-	)
-
-	progressTicker := time.NewTicker(5 * time.Second)
-	defer progressTicker.Stop()
-
-	processingDone := make(chan struct{})
-
+	var blockProcessingWG sync.WaitGroup
+	blockProcessingWG.Add(1)
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-progressTicker.C:
-				processedTxMu.Lock()
-				numProcessed := len(processedTxs)
-				processedTxMu.Unlock()
+		defer blockProcessingWG.Done()
+		defer close(blockProcessingDone)
 
-				txsMu.Lock()
-				numTotal := len(allTxs)
-				txsMu.Unlock()
-
-				t.Logf("Progress: mempool size=%d, processed=%d, total=%d",
-					env.mempool.Len(), numProcessed, numTotal)
-			}
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer close(processingDone)
-		ticker := time.NewTicker(100 * time.Millisecond)
+		ticker := time.NewTicker(200 * time.Millisecond)
 		defer ticker.Stop()
 
 		for {
@@ -127,143 +115,159 @@ func TestLoadFIFOUnderHighConcurrency(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				select {
+				case <-txCreationDone:
+				default:
+					continue
+				}
+
 				if env.mempool.Len() > 0 {
+					time.Sleep(networkLatency)
+
 					toProcess := min(env.mempool.Len(), maxTxsPerBlock)
-					t.Logf("Building block with %d transactions (mempool size: %d)",
-						toProcess, env.mempool.Len())
 
 					blkIntf, err := env.Builder.BuildBlock(ctx)
 					if err != nil {
-						t.Logf("Failed to build block: %v", err)
-						time.Sleep(time.Second)
+						t.Logf("Block build error: %v", err)
+						rejectedTxCounter.Add(int64(toProcess))
 						continue
 					}
 
 					blk := blkIntf.(*blockexecutor.Block)
 					if err := blk.Verify(ctx); err != nil {
-						t.Logf("Failed to verify block: %v", err)
+						t.Logf("Block verification error: %v, block size: %d, num txs: %d",
+							err,
+							len(blk.Bytes()),
+							len(blk.Txs()))
+						rejectedTxCounter.Add(int64(toProcess))
 						continue
 					}
 
 					if err := blk.Accept(ctx); err != nil {
-						t.Logf("Failed to accept block: %v", err)
+						t.Logf("Block acceptance error: %v", err)
+						rejectedTxCounter.Add(int64(toProcess))
 						continue
 					}
 
 					processedTxMu.Lock()
-					processedTxs = append(processedTxs, blk.Txs()...)
-					currentProcessed := len(processedTxs)
-					processedTxMu.Unlock()
-
-					t.Logf("Successfully processed block with %d transactions, total processed: %d",
-						len(blk.Txs()), currentProcessed)
-				} else {
-					processedTxMu.Lock()
-					txsMu.Lock()
-					if len(processedTxs) == len(allTxs) {
-						txsMu.Unlock()
-						processedTxMu.Unlock()
-						return
+					now := time.Now()
+					for _, tx := range blk.Txs() {
+						if info, exists := txsByID[tx.ID()]; exists {
+							info.processedAt = now
+							processedTxs = append(processedTxs, info)
+							processedTxCounter.Add(1)
+						}
 					}
-					txsMu.Unlock()
 					processedTxMu.Unlock()
 				}
+
+				processedTxMu.Lock()
+				txsMu.RLock()
+				if len(processedTxs) == len(allTxs) {
+					txsMu.RUnlock()
+					processedTxMu.Unlock()
+					return
+				}
+				txsMu.RUnlock()
+				processedTxMu.Unlock()
 			}
 		}
 	}()
 
+	var txCreationWG sync.WaitGroup
 	for g := 0; g < numGoroutines; g++ {
-		wg.Add(1)
+		txCreationWG.Add(1)
 		go func(goroutineID int) {
-			defer wg.Done()
+			defer txCreationWG.Done()
 			baseIndex := goroutineID * txsPerGoroutine
 
 			for i := 0; i < txsPerGoroutine; i++ {
 				select {
 				case <-ctx.Done():
-					t.Logf("Transaction creation goroutine %d stopping", goroutineID)
 					return
 				default:
-				}
+					globalIndex := baseIndex + i
+					now := time.Now()
 
-				globalIndex := baseIndex + i
-				tx, err := createRandomTx(globalIndex)
-				if err != nil {
-					t.Logf("Goroutine %d failed to create transaction %d: %v",
-						goroutineID, globalIndex, err)
-					continue
-				}
+					tx, err := createEnhancedTx(globalIndex, env)
+					if err != nil {
+						t.Logf("Transaction creation error in goroutine %d: %v", goroutineID, err)
+						continue
+					}
 
-				txsMu.Lock()
-				allTxs = append(allTxs, tx)
-				txsByID[tx.ID()] = txInfo{
-					tx:    tx,
-					index: len(allTxs) - 1,
-				}
-				txsMu.Unlock()
+					txInfo := &enhancedTxInfo{
+						tx:        tx,
+						index:     globalIndex,
+						createdAt: now,
+					}
 
-				if err := env.mempool.Add(tx); err != nil {
-					t.Logf("Goroutine %d failed to add transaction %d to mempool: %v",
-						goroutineID, globalIndex, err)
-					continue
-				}
+					txsMu.Lock()
+					allTxs = append(allTxs, txInfo)
+					txsByID[tx.ID()] = txInfo
+					txsMu.Unlock()
 
-				if i%10 == 0 {
-					t.Logf("Goroutine %d created %d/%d transactions",
-						goroutineID, i+1, txsPerGoroutine)
-				}
+					if err := env.mempool.Add(tx); err != nil {
+						t.Logf("Mempool addition error: %v", err)
+						continue
+					}
+					txInfo.addedAt = time.Now()
 
-				time.Sleep(time.Millisecond)
+					createdTxCount.Add(1)
+				}
 			}
-			t.Logf("Goroutine %d completed creating transactions", goroutineID)
 		}(g)
 	}
 
-	creationDone := make(chan struct{})
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
 	go func() {
-		wg.Wait()
-		close(creationDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				t.Logf("Progress - Created: %d, Processed: %d, Rejected: %d, In mempool: %d",
+					createdTxCount.Load(),
+					processedTxCounter.Load(),
+					rejectedTxCounter.Load(),
+					env.mempool.Len(),
+				)
+			}
+		}
 	}()
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("Test timed out")
-	case <-creationDone:
-		t.Log("All transactions created")
-		select {
-		case <-ctx.Done():
-			t.Fatal("Test timed out waiting for processing")
-		case <-processingDone:
-			t.Log("All transactions processed")
-		}
-	}
+	txCreationWG.Wait()
+	close(txCreationDone)
 
-	for env.mempool.Len() > 0 {
-		t.Log("Waiting for remaining transactions to be processed")
-		time.Sleep(time.Second)
-	}
+	blockProcessingWG.Wait()
 
-	txsMu.Lock()
-	numTotalTxs := len(allTxs)
-	txsMu.Unlock()
+	txsMu.RLock()
+	totalExpectedTxs := len(allTxs)
+	txsMu.RUnlock()
 
 	processedTxMu.Lock()
-	numProcessedTxs := len(processedTxs)
+	processedTxCount := len(processedTxs)
 	processedTxMu.Unlock()
 
-	require.Equal(numTotalTxs, numProcessedTxs,
-		"Number of processed transactions (%d) doesn't match total transactions (%d)",
-		numProcessedTxs, numTotalTxs)
+	t.Logf("Total Transactions: %d", totalExpectedTxs)
+	t.Logf("Processed Transactions: %d", processedTxCount)
+	t.Logf("Rejected Transactions: %d", rejectedTxCounter.Load())
 
-	var lastIndex int = -1
-	for _, tx := range processedTxs {
-		info, exists := txsByID[tx.ID()]
-		require.True(exists, "Transaction %s was processed but not found in created transactions", tx.ID())
-		require.Greater(info.index, lastIndex,
-			"FIFO order violated: transaction %d processed after %d", info.index, lastIndex)
-		lastIndex = info.index
+	require.Equal(totalExpectedTxs, processedTxCount,
+		"Not all transactions were processed")
+
+	const timeEpsilon = 50 * time.Microsecond
+
+	var lastAddedTime time.Time
+	for _, txInfo := range processedTxs {
+		timeDiff := txInfo.addedAt.Sub(lastAddedTime)
+		require.True(timeDiff >= -timeEpsilon,
+			"FIFO order violated: transaction processed out of queue order (time difference: %v)",
+			timeDiff)
+		lastAddedTime = txInfo.addedAt
 	}
 
-	require.Zero(env.mempool.Len(), "Mempool is not empty after processing all transactions")
-	t.Log("Test completed successfully")
+	require.Zero(env.mempool.Len(), "Mempool should be empty after processing")
+	t.Log("Enhanced FIFO Test Completed Successfully")
 }

--- a/vms/platformvm/block/executor/acceptor.go
+++ b/vms/platformvm/block/executor/acceptor.go
@@ -262,6 +262,15 @@ func (a *acceptor) standardBlock(b block.Block, blockType string) error {
 		zap.Stringer("utxoChecksum", a.state.Checksum()),
 	)
 
+	for _, tx := range b.Txs() {
+		txID := tx.ID()
+
+		a.ctx.Log.Info("Transaction accepted in block",
+			zap.Stringer("txID", txID),
+			zap.Stringer("blockID", blkID),
+		)
+	}
+
 	return nil
 }
 

--- a/vms/platformvm/manipulation/config.go
+++ b/vms/platformvm/manipulation/config.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package manipulation
+
+// Config holds the configuration for transaction manipulation
+type Config struct {
+	// Enabled indicates whether manipulation is enabled for the node
+	Enabled bool `json:"enabled"`
+
+	// CensorshipEnabled enables transaction censorship
+	CensorshipEnabled bool `json:"censorshipEnabled"`
+	// CensoredAddresses is a list of addresses whose transactions should be censored
+	CensoredAddresses []string `json:"censoredAddresses"`
+
+	// ReorderingEnabled enables transaction reordering
+	ReorderingEnabled bool `json:"reorderingEnabled"`
+	// ReorderedAddresses is a list of addresses whose transactions should be prioritized
+	ReorderedAddresses []string `json:"reorderedAddresses"`
+
+	// InjectionDetectionEnabled enables detection of transaction injection
+	InjectionDetectionEnabled bool `json:"injectionDetectionEnabled"`
+}
+
+// NewDefaultConfig returns a default configuration with all manipulations disabled
+func NewDefaultConfig() *Config {
+	return &Config{
+		Enabled:                   false,
+		CensorshipEnabled:         false,
+		CensoredAddresses:         []string{},
+		ReorderingEnabled:         false,
+		ReorderedAddresses:        []string{},
+		InjectionDetectionEnabled: false,
+	}
+}

--- a/vms/platformvm/manipulation/flags.go
+++ b/vms/platformvm/manipulation/flags.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package manipulation
+
+import (
+	"strings"
+)
+
+const (
+	// Prefixes for CLI flags
+	ManipulationPrefix = "manipulation"
+
+	// Main manipulation flags
+	EnabledFlag = "enabled"
+
+	// Censorship flags
+	CensorshipEnabledFlag = "censorship-enabled"
+	CensoredAddressesFlag = "censored-addresses"
+
+	// Reordering flags
+	ReorderingEnabledFlag  = "reordering-enabled"
+	ReorderedAddressesFlag = "reordered-addresses"
+
+	// Injection detection flags
+	InjectionDetectionEnabledFlag = "injection-detection-enabled"
+)
+
+// GetFlagNames returns the full flag names for P-Chain manipulation
+func GetFlagNames() map[string]string {
+	manipFlags := map[string]string{
+		EnabledFlag:                   "manipulation-enabled",
+		CensorshipEnabledFlag:         "manipulation-censorship-enabled",
+		CensoredAddressesFlag:         "manipulation-censored-addresses",
+		ReorderingEnabledFlag:         "manipulation-reordering-enabled",
+		ReorderedAddressesFlag:        "manipulation-reordered-addresses",
+		InjectionDetectionEnabledFlag: "manipulation-injection-detection-enabled",
+	}
+
+	return manipFlags
+}
+
+// GetManipulationKeysFromFlags maps the flag names to the corresponding configuration keys
+func GetManipulationKeysFromFlags() map[string]string {
+	manipFlags := GetFlagNames()
+
+	// Map CLI flags to config file keys
+	flagToKey := make(map[string]string, len(manipFlags))
+	for flagName, flagValue := range manipFlags {
+		key := strings.Replace(flagValue, "-", ".", -1)
+		flagToKey[flagName] = key
+	}
+
+	return flagToKey
+}
+
+// ConfigPrefix returns the prefix used for manipulation configuration keys
+// func ConfigPrefix() string {
+// 	return constants.PlatformKeyName + "." + ManipulationPrefix
+// }

--- a/vms/platformvm/manipulation/init.go
+++ b/vms/platformvm/manipulation/init.go
@@ -26,12 +26,11 @@ func InitGlobalConfig(configJSON string, log logging.Logger) error {
 		}
 
 		var config struct {
-			Enabled         bool     `json:"enabled"`
-			CensoredTxIDs   []string `json:"censored_tx_ids"`
-			PriorityTxIDs   []string `json:"priority_tx_ids"`
-			DetectInjection bool     `json:"detect_injection"`
+			Enabled           bool     `json:"enabled"`
+			CensoredAddresses []string `json:"censored_addresses"`
+			PriorityTxIDs     []string `json:"priority_tx_ids"`
+			DetectInjection   bool     `json:"detect_injection"`
 		}
-
 		if err = json.Unmarshal([]byte(configJSON), &config); err != nil {
 			err = fmt.Errorf("failed to parse config: %w", err)
 			log.Error("config parsing failed", zap.Error(err))
@@ -40,20 +39,20 @@ func InitGlobalConfig(configJSON string, log logging.Logger) error {
 
 		log.Debug("parsed config",
 			zap.Bool("enabled", config.Enabled),
-			zap.Int("censored_count", len(config.CensoredTxIDs)),
+			zap.Int("censored_count", len(config.CensoredAddresses)),
 			zap.Int("priority_count", len(config.PriorityTxIDs)),
 			zap.Bool("detect_injection", config.DetectInjection))
 
 		globalManipulator = New(config.Enabled, config.DetectInjection, log)
 
-		for _, idStr := range config.CensoredTxIDs {
-			txID, parseErr := ids.FromString(idStr)
+		for _, addrStr := range config.CensoredAddresses {
+			addr, parseErr := ids.ShortFromString(addrStr)
 			if parseErr != nil {
-				log.Warn("skipping invalid censored tx ID", zap.String("id", idStr), zap.Error(parseErr))
+				log.Warn("skipping invalid censored address", zap.String("addr", addrStr), zap.Error(parseErr))
 				continue
 			}
-			globalManipulator.AddCensoredTxID(txID)
-			log.Debug("added censored tx", zap.Stringer("txID", txID))
+			globalManipulator.AddCensoredAddress(addr)
+			log.Debug("added censored address", zap.Stringer("addr", addr))
 		}
 
 		for _, idStr := range config.PriorityTxIDs {
@@ -68,7 +67,7 @@ func InitGlobalConfig(configJSON string, log logging.Logger) error {
 
 		if config.Enabled {
 			log.Info("manipulation enabled",
-				zap.Int("censored", len(config.CensoredTxIDs)),
+				zap.Int("censored", len(config.CensoredAddresses)),
 				zap.Int("priority", len(config.PriorityTxIDs)),
 				zap.Bool("detect_injection", config.DetectInjection))
 		} else {
@@ -82,10 +81,10 @@ func InitGlobalConfig(configJSON string, log logging.Logger) error {
 func GetGlobalManipulator() *Manipulator {
 	if globalManipulator == nil {
 		globalManipulator = &Manipulator{
-			Enabled:         false,
-			CensoredTxIDs:   make(map[ids.ID]struct{}),
-			PriorityTxIDs:   make(map[ids.ID]struct{}),
-			DetectInjection: false,
+			Enabled:           false,
+			CensoredAddresses: make(map[ids.ShortID]struct{}),
+			PriorityTxIDs:     make(map[ids.ID]struct{}),
+			DetectInjection:   false,
 		}
 	}
 	return globalManipulator

--- a/vms/platformvm/manipulation/init.go
+++ b/vms/platformvm/manipulation/init.go
@@ -1,0 +1,92 @@
+package manipulation
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"go.uber.org/zap"
+)
+
+var (
+	globalManipulator *Manipulator
+	initOnce          sync.Once
+)
+
+func InitGlobalConfig(configJSON string, log logging.Logger) error {
+	var err error
+
+	initOnce.Do(func() {
+		if configJSON == "" {
+			globalManipulator = New(false, false, log)
+			log.Info("manipulation disabled", zap.String("reason", "empty config"))
+			return
+		}
+
+		var config struct {
+			Enabled         bool     `json:"enabled"`
+			CensoredTxIDs   []string `json:"censored_tx_ids"`
+			PriorityTxIDs   []string `json:"priority_tx_ids"`
+			DetectInjection bool     `json:"detect_injection"`
+		}
+
+		if err = json.Unmarshal([]byte(configJSON), &config); err != nil {
+			err = fmt.Errorf("failed to parse config: %w", err)
+			log.Error("config parsing failed", zap.Error(err))
+			return
+		}
+
+		log.Debug("parsed config",
+			zap.Bool("enabled", config.Enabled),
+			zap.Int("censored_count", len(config.CensoredTxIDs)),
+			zap.Int("priority_count", len(config.PriorityTxIDs)),
+			zap.Bool("detect_injection", config.DetectInjection))
+
+		globalManipulator = New(config.Enabled, config.DetectInjection, log)
+
+		for _, idStr := range config.CensoredTxIDs {
+			txID, parseErr := ids.FromString(idStr)
+			if parseErr != nil {
+				log.Warn("skipping invalid censored tx ID", zap.String("id", idStr), zap.Error(parseErr))
+				continue
+			}
+			globalManipulator.AddCensoredTxID(txID)
+			log.Debug("added censored tx", zap.Stringer("txID", txID))
+		}
+
+		for _, idStr := range config.PriorityTxIDs {
+			txID, parseErr := ids.FromString(idStr)
+			if parseErr != nil {
+				log.Warn("skipping invalid priority tx ID", zap.String("id", idStr), zap.Error(parseErr))
+				continue
+			}
+			globalManipulator.AddPriorityTxID(txID)
+			log.Debug("added priority tx", zap.Stringer("txID", txID))
+		}
+
+		if config.Enabled {
+			log.Info("manipulation enabled",
+				zap.Int("censored", len(config.CensoredTxIDs)),
+				zap.Int("priority", len(config.PriorityTxIDs)),
+				zap.Bool("detect_injection", config.DetectInjection))
+		} else {
+			log.Info("manipulation disabled")
+		}
+	})
+
+	return err
+}
+
+func GetGlobalManipulator() *Manipulator {
+	if globalManipulator == nil {
+		globalManipulator = &Manipulator{
+			Enabled:         false,
+			CensoredTxIDs:   make(map[ids.ID]struct{}),
+			PriorityTxIDs:   make(map[ids.ID]struct{}),
+			DetectInjection: false,
+		}
+	}
+	return globalManipulator
+}

--- a/vms/platformvm/manipulation/manipulator.go
+++ b/vms/platformvm/manipulation/manipulator.go
@@ -1,0 +1,99 @@
+package manipulation
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	platform "github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"go.uber.org/zap"
+)
+
+type Manipulator struct {
+	Enabled         bool
+	CensoredTxIDs   map[ids.ID]struct{}
+	PriorityTxIDs   map[ids.ID]struct{}
+	DetectInjection bool
+	log             logging.Logger
+}
+
+func New(enabled, detectInjection bool, log logging.Logger) *Manipulator {
+	return &Manipulator{
+		Enabled:         enabled,
+		CensoredTxIDs:   make(map[ids.ID]struct{}),
+		PriorityTxIDs:   make(map[ids.ID]struct{}),
+		DetectInjection: detectInjection,
+		log:             log,
+	}
+}
+
+func (m *Manipulator) ShouldCensor(txID ids.ID) bool {
+	if !m.Enabled {
+		m.log.Debug("manipulator off, no censor check", zap.Stringer("txID", txID))
+		return false
+	}
+	_, shouldCensor := m.CensoredTxIDs[txID]
+	if shouldCensor {
+		m.log.Info("censoring tx", zap.Stringer("txID", txID))
+	} else {
+		m.log.Debug("tx not censored", zap.Stringer("txID", txID))
+	}
+	return shouldCensor
+}
+
+func (m *Manipulator) ShouldPrioritize(txID ids.ID) bool {
+	if !m.Enabled {
+		m.log.Debug("manipulator off, no priority check", zap.Stringer("txID", txID))
+		return false
+	}
+	_, shouldPrioritize := m.PriorityTxIDs[txID]
+	if shouldPrioritize {
+		m.log.Info("prioritizing tx", zap.Stringer("txID", txID))
+	} else {
+		m.log.Debug("tx not prioritized", zap.Stringer("txID", txID))
+	}
+	return shouldPrioritize
+}
+
+func (m *Manipulator) ShouldDropAsInjection(tx *platform.Tx, hasTxNumber bool) bool {
+	if !m.Enabled || !m.DetectInjection {
+		m.log.Debug("injection check skipped", zap.Bool("enabled", m.Enabled), zap.Bool("detectInjection", m.DetectInjection))
+		return false
+	}
+	if !hasTxNumber && tx != nil {
+		txID := tx.ID()
+		m.log.Info("possible injection detected", zap.Stringer("txID", txID), zap.Bool("hasTxNumber", hasTxNumber))
+		return true
+	}
+	m.log.Debug("no injection", zap.Bool("hasTxNumber", hasTxNumber), zap.Any("tx", tx))
+	return false
+}
+
+func (m *Manipulator) ApplyReordering(txs []*platform.Tx) []*platform.Tx {
+	if !m.Enabled || len(txs) <= 1 {
+		m.log.Debug("reordering skipped", zap.Bool("enabled", m.Enabled), zap.Int("txCount", len(txs)))
+		return txs
+	}
+
+	var prioritized, regular []*platform.Tx
+	for _, tx := range txs {
+		txID := tx.ID()
+		if m.ShouldPrioritize(txID) {
+			prioritized = append(prioritized, tx)
+			m.log.Debug("tx prioritized", zap.Stringer("txID", txID))
+		} else {
+			regular = append(regular, tx)
+			m.log.Debug("tx regular", zap.Stringer("txID", txID))
+		}
+	}
+	m.log.Info("txs reordered", zap.Int("prioritized", len(prioritized)), zap.Int("regular", len(regular)))
+	return append(prioritized, regular...)
+}
+
+func (m *Manipulator) AddCensoredTxID(txID ids.ID) {
+	m.CensoredTxIDs[txID] = struct{}{}
+	m.log.Info("tx added to censor list", zap.Stringer("txID", txID))
+}
+
+func (m *Manipulator) AddPriorityTxID(txID ids.ID) {
+	m.PriorityTxIDs[txID] = struct{}{}
+	m.log.Info("tx added to priority list", zap.Stringer("txID", txID))
+}

--- a/vms/platformvm/manipulation/manipulator.go
+++ b/vms/platformvm/manipulation/manipulator.go
@@ -2,41 +2,72 @@ package manipulation
 
 import (
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	platform "github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"go.uber.org/zap"
 )
 
 type Manipulator struct {
-	Enabled         bool
-	CensoredTxIDs   map[ids.ID]struct{}
-	PriorityTxIDs   map[ids.ID]struct{}
-	DetectInjection bool
-	log             logging.Logger
+	Enabled           bool
+	CensoredAddresses map[ids.ShortID]struct{}
+	PriorityTxIDs     map[ids.ID]struct{}
+	DetectInjection   bool
+	log               logging.Logger
 }
 
 func New(enabled, detectInjection bool, log logging.Logger) *Manipulator {
 	return &Manipulator{
-		Enabled:         enabled,
-		CensoredTxIDs:   make(map[ids.ID]struct{}),
-		PriorityTxIDs:   make(map[ids.ID]struct{}),
-		DetectInjection: detectInjection,
-		log:             log,
+		Enabled:           enabled,
+		CensoredAddresses: make(map[ids.ShortID]struct{}),
+		PriorityTxIDs:     make(map[ids.ID]struct{}),
+		DetectInjection:   detectInjection,
+		log:               log,
 	}
 }
 
-func (m *Manipulator) ShouldCensor(txID ids.ID) bool {
+func (m *Manipulator) ShouldCensor(tx *platform.Tx) bool {
 	if !m.Enabled {
-		m.log.Debug("manipulator off, no censor check", zap.Stringer("txID", txID))
+		m.log.Debug("manipulator off, no censor check", zap.Stringer("txID", tx.ID()))
 		return false
 	}
-	_, shouldCensor := m.CensoredTxIDs[txID]
-	if shouldCensor {
-		m.log.Info("censoring tx", zap.Stringer("txID", txID))
-	} else {
-		m.log.Debug("tx not censored", zap.Stringer("txID", txID))
+
+	unsignedTx := tx.Unsigned
+	for _, cred := range tx.Creds {
+		if secpCred, ok := cred.(*secp256k1fx.Credential); ok {
+			for _, sig := range secpCred.Sigs {
+				pubKey, err := secp256k1.RecoverPublicKey(unsignedTx.Bytes(), sig[:])
+				if err != nil {
+					m.log.Warn("failed to recover public key", zap.Error(err), zap.Stringer("txID", tx.ID()))
+					continue
+				}
+				addr := pubKey.Address()
+				if _, censored := m.CensoredAddresses[addr]; censored {
+					m.log.Info("censoring tx by sender address",
+						zap.Stringer("txID", tx.ID()),
+						zap.Stringer("addr", addr))
+					return true
+				}
+			}
+		}
 	}
-	return shouldCensor
+
+	for _, out := range unsignedTx.Outputs() {
+		if transferOut, ok := out.Out.(*secp256k1fx.TransferOutput); ok {
+			for _, addr := range transferOut.Addrs {
+				if _, censored := m.CensoredAddresses[addr]; censored {
+					m.log.Info("censoring tx by recipient address",
+						zap.Stringer("txID", tx.ID()),
+						zap.Stringer("addr", addr))
+					return true
+				}
+			}
+		}
+	}
+
+	m.log.Debug("tx not censored", zap.Stringer("txID", tx.ID()))
+	return false
 }
 
 func (m *Manipulator) ShouldPrioritize(txID ids.ID) bool {
@@ -47,8 +78,6 @@ func (m *Manipulator) ShouldPrioritize(txID ids.ID) bool {
 	_, shouldPrioritize := m.PriorityTxIDs[txID]
 	if shouldPrioritize {
 		m.log.Info("prioritizing tx", zap.Stringer("txID", txID))
-	} else {
-		m.log.Debug("tx not prioritized", zap.Stringer("txID", txID))
 	}
 	return shouldPrioritize
 }
@@ -59,8 +88,7 @@ func (m *Manipulator) ShouldDropAsInjection(tx *platform.Tx, hasTxNumber bool) b
 		return false
 	}
 	if !hasTxNumber && tx != nil {
-		txID := tx.ID()
-		m.log.Info("possible injection detected", zap.Stringer("txID", txID), zap.Bool("hasTxNumber", hasTxNumber))
+		m.log.Info("possible injection detected", zap.Stringer("txID", tx.ID()), zap.Bool("hasTxNumber", hasTxNumber))
 		return true
 	}
 	m.log.Debug("no injection", zap.Bool("hasTxNumber", hasTxNumber), zap.Any("tx", tx))
@@ -88,9 +116,9 @@ func (m *Manipulator) ApplyReordering(txs []*platform.Tx) []*platform.Tx {
 	return append(prioritized, regular...)
 }
 
-func (m *Manipulator) AddCensoredTxID(txID ids.ID) {
-	m.CensoredTxIDs[txID] = struct{}{}
-	m.log.Info("tx added to censor list", zap.Stringer("txID", txID))
+func (m *Manipulator) AddCensoredAddress(addr ids.ShortID) {
+	m.CensoredAddresses[addr] = struct{}{}
+	m.log.Info("address added to censor list", zap.Stringer("addr", addr))
 }
 
 func (m *Manipulator) AddPriorityTxID(txID ids.ID) {

--- a/vms/platformvm/manipulation/manipulator_test.go
+++ b/vms/platformvm/manipulation/manipulator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/stretchr/testify/require"
@@ -46,43 +47,16 @@ func TestManipulator(t *testing.T) {
 		m := manipulation.New(true, true, logger)
 		require.True(t, m.Enabled)
 		require.True(t, m.DetectInjection)
-		require.NotNil(t, m.CensoredTxIDs)
+		require.NotNil(t, m.CensoredAddresses)
 		require.NotNil(t, m.PriorityTxIDs)
-		require.Zero(t, len(m.CensoredTxIDs))
+		require.Zero(t, len(m.CensoredAddresses))
 		require.Zero(t, len(m.PriorityTxIDs))
 	})
 
-	t.Run("Blocked Addresses Censorship", func(t *testing.T) {
+	t.Run("BlockedAddressesCensorship", func(t *testing.T) {
 		m := manipulation.New(true, true, logger)
-		censor := &struct {
-			manipulator      *manipulation.Manipulator
-			blockedAddresses map[ids.ShortID]struct{}
-			blockedTxIDs     map[ids.ID]struct{}
-		}{
-			manipulator:      m,
-			blockedAddresses: make(map[ids.ShortID]struct{}),
-			blockedTxIDs:     make(map[ids.ID]struct{}),
-		}
-
 		for _, addr := range blockedAddresses {
-			censor.blockedAddresses[addr] = struct{}{}
-		}
-
-		isCensored := func(tx *txs.Tx) bool {
-			baseTx, ok := tx.Unsigned.(*txs.BaseTx)
-			if !ok {
-				return false
-			}
-			for _, out := range baseTx.Outs {
-				if transferOut, ok := out.Out.(*secp256k1fx.TransferOutput); ok {
-					for _, addr := range transferOut.Addrs {
-						if _, exists := censor.blockedAddresses[addr]; exists {
-							return true
-						}
-					}
-				}
-			}
-			return false
+			m.AddCensoredAddress(addr)
 		}
 
 		for i, key := range wallets {
@@ -108,23 +82,24 @@ func TestManipulator(t *testing.T) {
 			}
 			err := tx.Initialize(codecManager)
 			require.NoError(t, err)
+
 			txID := ids.GenerateTestID()
 			tx.SetBytes(tx.Unsigned.Bytes(), txID[:])
+			sig, err := key.Sign(tx.Unsigned.Bytes())
+			require.NoError(t, err)
+			var sigArray [65]byte
+			copy(sigArray[:], sig)
+			tx.Creds = []verify.Verifiable{&secp256k1fx.Credential{Sigs: [][65]byte{sigArray}}}
 
-			censored := isCensored(tx)
-			if i < 2 {
-				require.True(t, censored)
-				m.AddCensoredTxID(tx.ID())
-				require.True(t, m.ShouldCensor(tx.ID()))
+			if i < 2 { // blockedAddresses = addresses[:2]
+				require.True(t, m.ShouldCensor(tx), "Transaction from/to blocked address should be censored")
 			} else {
-				require.False(t, censored)
-				require.False(t, m.ShouldCensor(tx.ID()))
+				require.False(t, m.ShouldCensor(tx), "Transaction from/to non-blocked address should not be censored")
 			}
-			require.False(t, m.ShouldCensor(ids.GenerateTestID()))
 		}
 	})
 
-	t.Run("Priority Transactions", func(t *testing.T) {
+	t.Run("PriorityTransactions", func(t *testing.T) {
 		m := manipulation.New(true, true, logger)
 		key := wallets[2]
 		tx := newTx(t, codecManager, key, 1000)
@@ -156,17 +131,9 @@ func TestManipulator(t *testing.T) {
 		require.Equal(t, tx.ID(), reordered[0].ID())
 		require.False(t, m.ShouldPrioritize(reordered[1].ID()))
 		require.False(t, m.ShouldPrioritize(reordered[2].ID()))
-
-		shortList := []*txs.Tx{tx1}
-		reordered = m.ApplyReordering(shortList)
-		require.Equal(t, shortList, reordered)
-
-		emptyList := []*txs.Tx{}
-		reordered = m.ApplyReordering(emptyList)
-		require.Empty(t, reordered)
 	})
 
-	t.Run("Injection Detection", func(t *testing.T) {
+	t.Run("InjectionDetection", func(t *testing.T) {
 		m := manipulation.New(true, true, logger)
 		tx := newTx(t, codecManager, nil, 0)
 		require.False(t, m.ShouldDropAsInjection(tx, true))
@@ -180,13 +147,19 @@ func TestManipulator(t *testing.T) {
 		require.False(t, m.ShouldDropAsInjection(tx, false))
 	})
 
-	t.Run("Disabled Manipulations", func(t *testing.T) {
+	t.Run("DisabledManipulations", func(t *testing.T) {
 		m := manipulation.New(false, true, logger)
-		tx := newTx(t, codecManager, nil, 0)
-		m.AddCensoredTxID(tx.ID())
+		tx := newTx(t, codecManager, wallets[0], 1000)
+		sig, err := wallets[0].Sign(tx.Unsigned.Bytes())
+		require.NoError(t, err)
+		var sigArray [65]byte
+		copy(sigArray[:], sig)
+		tx.Creds = []verify.Verifiable{&secp256k1fx.Credential{Sigs: [][65]byte{sigArray}}}
+
+		m.AddCensoredAddress(wallets[0].PublicKey().Address())
 		m.AddPriorityTxID(tx.ID())
 
-		require.False(t, m.ShouldCensor(tx.ID()))
+		require.False(t, m.ShouldCensor(tx))
 		require.False(t, m.ShouldPrioritize(tx.ID()))
 		require.False(t, m.ShouldDropAsInjection(tx, false))
 

--- a/vms/platformvm/manipulation/manipulator_test.go
+++ b/vms/platformvm/manipulation/manipulator_test.go
@@ -1,0 +1,220 @@
+package manipulation_test
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/vms/platformvm/manipulation"
+)
+
+func TestManipulator(t *testing.T) {
+	logger := logging.NoLog{}
+	codecManager := codec.NewManager(1024 * 1024)
+	c := linearcodec.New([]string{})
+
+	err := c.RegisterType(&txs.BaseTx{})
+	require.NoError(t, err)
+	err = c.RegisterType(&secp256k1fx.TransferInput{})
+	require.NoError(t, err)
+	err = c.RegisterType(&secp256k1fx.TransferOutput{})
+	require.NoError(t, err)
+	err = c.RegisterType(&secp256k1fx.Credential{})
+	require.NoError(t, err)
+	err = codecManager.RegisterCodec(txs.CodecVersion, c)
+	require.NoError(t, err)
+
+	wallets := make([]*secp256k1.PrivateKey, 5)
+	addresses := make([]ids.ShortID, 5)
+	for i := 0; i < 5; i++ {
+		key, err := secp256k1.NewPrivateKey()
+		require.NoError(t, err)
+		wallets[i] = key
+		addresses[i] = key.PublicKey().Address()
+	}
+	blockedAddresses := addresses[:2]
+
+	t.Run("Initialization", func(t *testing.T) {
+		m := manipulation.New(true, true, logger)
+		require.True(t, m.Enabled)
+		require.True(t, m.DetectInjection)
+		require.NotNil(t, m.CensoredTxIDs)
+		require.NotNil(t, m.PriorityTxIDs)
+		require.Zero(t, len(m.CensoredTxIDs))
+		require.Zero(t, len(m.PriorityTxIDs))
+	})
+
+	t.Run("Blocked Addresses Censorship", func(t *testing.T) {
+		m := manipulation.New(true, true, logger)
+		censor := &struct {
+			manipulator      *manipulation.Manipulator
+			blockedAddresses map[ids.ShortID]struct{}
+			blockedTxIDs     map[ids.ID]struct{}
+		}{
+			manipulator:      m,
+			blockedAddresses: make(map[ids.ShortID]struct{}),
+			blockedTxIDs:     make(map[ids.ID]struct{}),
+		}
+
+		for _, addr := range blockedAddresses {
+			censor.blockedAddresses[addr] = struct{}{}
+		}
+
+		isCensored := func(tx *txs.Tx) bool {
+			baseTx, ok := tx.Unsigned.(*txs.BaseTx)
+			if !ok {
+				return false
+			}
+			for _, out := range baseTx.Outs {
+				if transferOut, ok := out.Out.(*secp256k1fx.TransferOutput); ok {
+					for _, addr := range transferOut.Addrs {
+						if _, exists := censor.blockedAddresses[addr]; exists {
+							return true
+						}
+					}
+				}
+			}
+			return false
+		}
+
+		for i, key := range wallets {
+			tx := &txs.Tx{
+				Unsigned: &txs.BaseTx{
+					BaseTx: avax.BaseTx{
+						NetworkID:    1,
+						BlockchainID: ids.Empty,
+						Ins: []*avax.TransferableInput{{
+							UTXOID: avax.UTXOID{TxID: ids.GenerateTestID()},
+							Asset:  avax.Asset{ID: ids.Empty},
+							In:     &secp256k1fx.TransferInput{Amt: 1000, Input: secp256k1fx.Input{SigIndices: []uint32{0}}},
+						}},
+						Outs: []*avax.TransferableOutput{{
+							Asset: avax.Asset{ID: ids.Empty},
+							Out: &secp256k1fx.TransferOutput{
+								Amt:          1000,
+								OutputOwners: secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{key.PublicKey().Address()}},
+							},
+						}},
+					},
+				},
+			}
+			err := tx.Initialize(codecManager)
+			require.NoError(t, err)
+			txID := ids.GenerateTestID()
+			tx.SetBytes(tx.Unsigned.Bytes(), txID[:])
+
+			censored := isCensored(tx)
+			if i < 2 {
+				require.True(t, censored)
+				m.AddCensoredTxID(tx.ID())
+				require.True(t, m.ShouldCensor(tx.ID()))
+			} else {
+				require.False(t, censored)
+				require.False(t, m.ShouldCensor(tx.ID()))
+			}
+			require.False(t, m.ShouldCensor(ids.GenerateTestID()))
+		}
+	})
+
+	t.Run("Priority Transactions", func(t *testing.T) {
+		m := manipulation.New(true, true, logger)
+		key := wallets[2]
+		tx := newTx(t, codecManager, key, 1000)
+		m.AddPriorityTxID(tx.ID())
+		require.True(t, m.ShouldPrioritize(tx.ID()))
+		require.False(t, m.ShouldPrioritize(ids.GenerateTestID()))
+
+		tx1 := newTx(t, codecManager, nil, 0)
+		tx2 := newTx(t, codecManager, nil, 0)
+		tx3 := newTx(t, codecManager, nil, 0)
+
+		m.AddPriorityTxID(tx1.ID())
+		m.AddPriorityTxID(tx2.ID())
+		txsList := []*txs.Tx{tx1, tx2, tx}
+		reordered := m.ApplyReordering(txsList)
+		require.Equal(t, 3, len(reordered))
+		require.True(t, m.ShouldPrioritize(reordered[0].ID()))
+		require.True(t, m.ShouldPrioritize(reordered[1].ID()))
+		require.True(t, m.ShouldPrioritize(reordered[2].ID()))
+
+		m = manipulation.New(true, true, logger)
+		txsList = []*txs.Tx{tx1, tx2, tx3}
+		reordered = m.ApplyReordering(txsList)
+		require.Equal(t, txsList, reordered)
+
+		txsList = []*txs.Tx{tx1, tx, tx3}
+		m.AddPriorityTxID(tx.ID())
+		reordered = m.ApplyReordering(txsList)
+		require.Equal(t, tx.ID(), reordered[0].ID())
+		require.False(t, m.ShouldPrioritize(reordered[1].ID()))
+		require.False(t, m.ShouldPrioritize(reordered[2].ID()))
+
+		shortList := []*txs.Tx{tx1}
+		reordered = m.ApplyReordering(shortList)
+		require.Equal(t, shortList, reordered)
+
+		emptyList := []*txs.Tx{}
+		reordered = m.ApplyReordering(emptyList)
+		require.Empty(t, reordered)
+	})
+
+	t.Run("Injection Detection", func(t *testing.T) {
+		m := manipulation.New(true, true, logger)
+		tx := newTx(t, codecManager, nil, 0)
+		require.False(t, m.ShouldDropAsInjection(tx, true))
+		require.True(t, m.ShouldDropAsInjection(tx, false))
+		require.False(t, m.ShouldDropAsInjection(nil, false))
+
+		m = manipulation.New(true, false, logger)
+		require.False(t, m.ShouldDropAsInjection(tx, false))
+
+		m = manipulation.New(false, true, logger)
+		require.False(t, m.ShouldDropAsInjection(tx, false))
+	})
+
+	t.Run("Disabled Manipulations", func(t *testing.T) {
+		m := manipulation.New(false, true, logger)
+		tx := newTx(t, codecManager, nil, 0)
+		m.AddCensoredTxID(tx.ID())
+		m.AddPriorityTxID(tx.ID())
+
+		require.False(t, m.ShouldCensor(tx.ID()))
+		require.False(t, m.ShouldPrioritize(tx.ID()))
+		require.False(t, m.ShouldDropAsInjection(tx, false))
+
+		txsList := []*txs.Tx{tx}
+		reordered := m.ApplyReordering(txsList)
+		require.Equal(t, txsList, reordered)
+	})
+}
+
+func newTx(t *testing.T, cm codec.Manager, key *secp256k1.PrivateKey, amt uint64) *txs.Tx {
+	tx := &txs.Tx{Unsigned: &txs.BaseTx{BaseTx: avax.BaseTx{NetworkID: 1, BlockchainID: ids.Empty}}}
+	if key != nil {
+		tx.Unsigned.(*txs.BaseTx).Ins = []*avax.TransferableInput{{
+			UTXOID: avax.UTXOID{TxID: ids.GenerateTestID()},
+			Asset:  avax.Asset{ID: ids.Empty},
+			In:     &secp256k1fx.TransferInput{Amt: amt, Input: secp256k1fx.Input{SigIndices: []uint32{0}}},
+		}}
+		tx.Unsigned.(*txs.BaseTx).Outs = []*avax.TransferableOutput{{
+			Asset: avax.Asset{ID: ids.Empty},
+			Out: &secp256k1fx.TransferOutput{
+				Amt:          amt,
+				OutputOwners: secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{key.PublicKey().Address()}},
+			},
+		}}
+	}
+	err := tx.Initialize(cm)
+	require.NoError(t, err)
+	txID := ids.GenerateTestID()
+	tx.SetBytes(tx.Unsigned.Bytes(), txID[:])
+	return tx
+}

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1434,6 +1434,14 @@ func (s *Service) IssueTx(_ *http.Request, args *api.FormattedTx, response *api.
 	}
 
 	response.TxID = tx.ID()
+	txID := tx.ID()
+	response.TxID = txID
+
+	txNum, exists := s.vm.GetTxNumber(txID)
+	if exists {
+		response.TxNum = txNum
+	}
+
 	return nil
 }
 

--- a/vms/platformvm/txs/counter/tx_counter.go
+++ b/vms/platformvm/txs/counter/tx_counter.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package counter
 
 import (
@@ -40,6 +43,7 @@ func (tc *TxCounter) Increment(txID ids.ID) uint64 {
 
 	tc.lock.Lock()
 	defer tc.lock.Unlock()
+
 	if metadata, exists := tc.txHistory[txID]; exists {
 		return metadata.Number
 	}
@@ -49,7 +53,6 @@ func (tc *TxCounter) Increment(txID ids.ID) uint64 {
 		Number:    newValue,
 		Timestamp: time.Now(),
 	}
-
 	return newValue
 }
 
@@ -60,6 +63,7 @@ func (tc *TxCounter) Get() uint64 {
 func (tc *TxCounter) GetTxMetadata(txID ids.ID) (TxMetadata, bool) {
 	tc.lock.RLock()
 	defer tc.lock.RUnlock()
+
 	metadata, exists := tc.txHistory[txID]
 	return metadata, exists
 }

--- a/vms/platformvm/txs/counter/tx_counter.go
+++ b/vms/platformvm/txs/counter/tx_counter.go
@@ -1,0 +1,69 @@
+package counter
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+type TxCounter struct {
+	counter   uint64
+	lock      sync.RWMutex
+	txHistory map[ids.ID]TxMetadata
+}
+
+type TxMetadata struct {
+	TxID      ids.ID
+	Number    uint64
+	Timestamp time.Time
+}
+
+func New() *TxCounter {
+	return &TxCounter{
+		counter:   0,
+		txHistory: make(map[ids.ID]TxMetadata),
+	}
+}
+
+func (tc *TxCounter) Increment(txID ids.ID) uint64 {
+	tc.lock.RLock()
+	if metadata, exists := tc.txHistory[txID]; exists {
+		tc.lock.RUnlock()
+		return metadata.Number
+	}
+	tc.lock.RUnlock()
+
+	newValue := atomic.AddUint64(&tc.counter, 1)
+
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
+	if metadata, exists := tc.txHistory[txID]; exists {
+		return metadata.Number
+	}
+
+	tc.txHistory[txID] = TxMetadata{
+		TxID:      txID,
+		Number:    newValue,
+		Timestamp: time.Now(),
+	}
+
+	return newValue
+}
+
+func (tc *TxCounter) Get() uint64 {
+	return atomic.LoadUint64(&tc.counter)
+}
+
+func (tc *TxCounter) GetTxMetadata(txID ids.ID) (TxMetadata, bool) {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
+	metadata, exists := tc.txHistory[txID]
+	return metadata, exists
+}
+
+func FormatTxID(txID ids.ID, txNum uint64) string {
+	return fmt.Sprintf("tx-%d (%s)", txNum, txID.String())
+}

--- a/vms/platformvm/txs/counter/tx_counter_test.go
+++ b/vms/platformvm/txs/counter/tx_counter_test.go
@@ -1,0 +1,82 @@
+package counter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+func TestTxCounter(t *testing.T) {
+	t.Run("Sequential Incrementation", func(t *testing.T) {
+		counter := New()
+		txs := []ids.ID{
+			ids.GenerateTestID(),
+			ids.GenerateTestID(),
+			ids.GenerateTestID(),
+		}
+
+		for i, txID := range txs {
+			expectedNum := uint64(i + 1)
+			num := counter.Increment(txID)
+			if num != expectedNum {
+				t.Errorf("Wrong transaction number: expected %d, got %d", expectedNum, num)
+			}
+			metadata, exists := counter.GetTxMetadata(txID)
+			if !exists {
+				t.Errorf("Transaction metadata doesn't exist")
+			}
+			if metadata.TxID != txID {
+				t.Errorf("Incorrect transaction ID in metadata")
+			}
+			if metadata.Number != expectedNum {
+				t.Errorf("Incorrect transaction number in metadata")
+			}
+		}
+		if counter.Get() != 3 {
+			t.Errorf("Total counter should be 3, got %d", counter.Get())
+		}
+	})
+
+	t.Run("Concurrent Incrementation", func(t *testing.T) {
+		counter := New()
+		const concurrentTxs = 100
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		seenNumbers := make(map[uint64]bool)
+
+		for i := 0; i < concurrentTxs; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				txID := ids.GenerateTestID()
+				num := counter.Increment(txID)
+				mu.Lock()
+				defer mu.Unlock()
+				if _, exists := seenNumbers[num]; exists {
+					t.Errorf("Transaction number %d already exists", num)
+				}
+				seenNumbers[num] = true
+			}()
+		}
+		wg.Wait()
+		if len(seenNumbers) != concurrentTxs {
+			t.Errorf("Expected %d unique numbers, got %d", concurrentTxs, len(seenNumbers))
+		}
+	})
+
+	t.Run("Repeated Transaction Handling", func(t *testing.T) {
+		counter := New()
+		uniqueTxID := ids.GenerateTestID()
+
+		firstNum := counter.Increment(uniqueTxID)
+		if firstNum != 1 {
+			t.Errorf("First transaction number should be 1, got %d", firstNum)
+		}
+
+		secondNum := counter.Increment(uniqueTxID)
+		if firstNum != secondNum {
+			t.Errorf("Transaction number changed: first %d, second %d", firstNum, secondNum)
+		}
+	})
+}

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/platformvm/txs/mempool/mempool.go
+++ b/vms/platformvm/txs/mempool/mempool.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/counter"
 	txmempool "github.com/ava-labs/avalanchego/vms/txs/mempool"
 )
 
@@ -30,12 +31,16 @@ type Mempool interface {
 	// a notification will only be sent if there is at least one transaction in
 	// the mempool.
 	RequestBuildBlock(emptyBlockPermitted bool)
+
+	// GetTxNumber returns the sequential number assigned to a transaction
+	GetTxNumber(txID ids.ID) (uint64, bool)
 }
 
 type mempool struct {
 	txmempool.Mempool[*txs.Tx]
 
-	toEngine chan<- common.Message
+	toEngine  chan<- common.Message
+	txCounter *counter.TxCounter
 }
 
 func New(
@@ -51,8 +56,9 @@ func New(
 		metrics,
 	)
 	return &mempool{
-		Mempool:  pool,
-		toEngine: toEngine,
+		Mempool:   pool,
+		toEngine:  toEngine,
+		txCounter: counter.New(),
 	}, nil
 }
 
@@ -65,7 +71,23 @@ func (m *mempool) Add(tx *txs.Tx) error {
 	default:
 	}
 
-	return m.Mempool.Add(tx)
+	err := m.Mempool.Add(tx)
+	if err != nil {
+		return err
+	}
+
+	txID := tx.ID()
+	m.txCounter.Increment(txID)
+
+	return nil
+}
+
+func (m *mempool) GetTxNumber(txID ids.ID) (uint64, bool) {
+	metadata, exists := m.txCounter.GetTxMetadata(txID)
+	if !exists {
+		return 0, false
+	}
+	return metadata.Number, true
 }
 
 func (m *mempool) RequestBuildBlock(emptyBlockPermitted bool) {

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -5,10 +5,12 @@ package platformvm
 
 import (
 	"context"
-	sjson "encoding/json"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/rpc/v2"
@@ -24,7 +26,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/uptime"
-	"github.com/ava-labs/avalanchego/utils/json"
+	ava_json "github.com/ava-labs/avalanchego/utils/json"
 
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
@@ -119,26 +121,65 @@ func (vm *VM) Initialize(
 	}
 	chainCtx.Log.Info("using VM execution config", zap.Reflect("config", execConfig))
 
-	// parse settings for manipulation from configBytes
+	chainCtx.Log.Info("raw configBytes", zap.String("bytes", string(configBytes)))
+
 	var manipConfig struct {
 		Manipulation struct {
-			Enabled         bool     `json:"enabled"`
-			CensoredTxIDs   []string `json:"censored_tx_ids"`
-			PriorityTxIDs   []string `json:"priority_tx_ids"`
-			DetectInjection bool     `json:"detect_injection"`
+			Enabled           bool     `json:"enabled"`
+			CensoredAddresses []string `json:"censored_addresses"`
+			PriorityTxIDs     []string `json:"priority_tx_ids"`
+			DetectInjection   bool     `json:"detect_injection"`
 		} `json:"manipulation"`
 	}
-	if len(configBytes) > 0 {
-		if err := sjson.Unmarshal(configBytes, &manipConfig); err != nil {
+	if len(configBytes) == 0 {
+		var configFile string
+		for i, arg := range os.Args {
+			if strings.HasPrefix(arg, "--config-file=") {
+				configFile = strings.TrimPrefix(arg, "--config-file=")
+				break
+			} else if arg == "--config-file" && i+1 < len(os.Args) {
+				configFile = os.Args[i+1]
+				break
+			}
+		}
+		if configFile == "" {
+			chainCtx.Log.Warn("no config-file provided, manipulation will be disabled")
+		} else {
+			configData, err := os.ReadFile(configFile)
+			if err != nil {
+				return fmt.Errorf("failed to read config file %s: %w", configFile, err)
+			}
+			var fullConfig struct {
+				Vms struct {
+					PlatformVM struct {
+						Manipulation struct {
+							Enabled           bool     `json:"enabled"`
+							CensoredAddresses []string `json:"censored_addresses"`
+							PriorityTxIDs     []string `json:"priority_tx_ids"`
+							DetectInjection   bool     `json:"detect_injection"`
+						} `json:"manipulation"`
+					} `json:"platformvm"`
+				} `json:"vms"`
+			}
+			if err := json.Unmarshal(configData, &fullConfig); err != nil {
+				return fmt.Errorf("failed to parse config.json: %w", err)
+			}
+			manipConfig.Manipulation = fullConfig.Vms.PlatformVM.Manipulation
+		}
+	} else {
+		if err := json.Unmarshal(configBytes, &manipConfig); err != nil {
 			return fmt.Errorf("failed to parse configBytes: %w", err)
 		}
 	}
 
-	// Turn into JSON for InitGlobalConfig
-	manipConfigJSON, err := sjson.Marshal(manipConfig.Manipulation)
+	chainCtx.Log.Info("manipConfig after unmarshal", zap.Any("config", manipConfig))
+
+	manipConfigJSON, err := json.Marshal(manipConfig.Manipulation)
 	if err != nil {
 		return fmt.Errorf("failed to marshal manipulation config: %w", err)
 	}
+	chainCtx.Log.Info("manipConfigJSON", zap.String("json", string(manipConfigJSON)))
+
 	if err := manipulation.InitGlobalConfig(string(manipConfigJSON), chainCtx.Log); err != nil {
 		chainCtx.Log.Warn("Failed to initialize manipulation config", zap.Error(err))
 	}
@@ -148,7 +189,6 @@ func (vm *VM) Initialize(
 		return err
 	}
 
-	// Initialize metrics as soon as possible
 	vm.metrics, err = platformvmmetrics.New(registerer)
 	if err != nil {
 		return fmt.Errorf("failed to initialize metrics: %w", err)
@@ -496,8 +536,8 @@ func (*VM) Version(context.Context) (string, error) {
 // * values are API handlers
 func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	server := rpc.NewServer()
-	server.RegisterCodec(json.NewCodec(), "application/json")
-	server.RegisterCodec(json.NewCodec(), "application/json;charset=UTF-8")
+	server.RegisterCodec(ava_json.NewCodec(), "application/json")
+	server.RegisterCodec(ava_json.NewCodec(), "application/json;charset=UTF-8")
 	server.RegisterInterceptFunc(vm.metrics.InterceptRequest)
 	server.RegisterAfterFunc(vm.metrics.AfterRequest)
 	service := &Service{

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -5,6 +5,7 @@ package platformvm
 
 import (
 	"context"
+	sjson "encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -23,10 +24,11 @@ import (
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/uptime"
+	"github.com/ava-labs/avalanchego/utils/json"
+
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/version"
@@ -34,6 +36,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
+	"github.com/ava-labs/avalanchego/vms/platformvm/manipulation"
 	"github.com/ava-labs/avalanchego/vms/platformvm/network"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -115,6 +118,30 @@ func (vm *VM) Initialize(
 		return err
 	}
 	chainCtx.Log.Info("using VM execution config", zap.Reflect("config", execConfig))
+
+	// parse settings for manipulation from configBytes
+	var manipConfig struct {
+		Manipulation struct {
+			Enabled         bool     `json:"enabled"`
+			CensoredTxIDs   []string `json:"censored_tx_ids"`
+			PriorityTxIDs   []string `json:"priority_tx_ids"`
+			DetectInjection bool     `json:"detect_injection"`
+		} `json:"manipulation"`
+	}
+	if len(configBytes) > 0 {
+		if err := sjson.Unmarshal(configBytes, &manipConfig); err != nil {
+			return fmt.Errorf("failed to parse configBytes: %w", err)
+		}
+	}
+
+	// Turn into JSON for InitGlobalConfig
+	manipConfigJSON, err := sjson.Marshal(manipConfig.Manipulation)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manipulation config: %w", err)
+	}
+	if err := manipulation.InitGlobalConfig(string(manipConfigJSON), chainCtx.Log); err != nil {
+		chainCtx.Log.Warn("Failed to initialize manipulation config", zap.Error(err))
+	}
 
 	registerer, err := metrics.MakeAndRegister(chainCtx.Metrics, "")
 	if err != nil {
@@ -221,6 +248,7 @@ func (vm *VM) Initialize(
 		mempool,
 		txExecutorBackend,
 		vm.manager,
+		manipulation.GetGlobalManipulator(),
 	)
 
 	// Create all of the chains that the database says exist

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/counter"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/vms/txs/mempool"
@@ -77,6 +78,8 @@ type VM struct {
 
 	state state.State
 
+	txCounter *counter.TxCounter
+
 	fx            fx.Fx
 	codecRegistry codec.Registry
 
@@ -105,6 +108,7 @@ func (vm *VM) Initialize(
 	appSender common.AppSender,
 ) error {
 	chainCtx.Log.Verbo("initializing platform chain")
+	vm.txCounter = counter.New()
 
 	execConfig, err := config.GetConfig(configBytes)
 	if err != nil {
@@ -249,6 +253,18 @@ func (vm *VM) Initialize(
 	}()
 
 	return nil
+}
+
+func (vm *VM) GetTxNumber(txID ids.ID) (uint64, bool) {
+	if vm.txCounter == nil {
+		return 0, false
+	}
+
+	metadata, exists := vm.txCounter.GetTxMetadata(txID)
+	if !exists {
+		return 0, false
+	}
+	return metadata.Number, true
 }
 
 func (vm *VM) periodicallyPruneMempool(frequency time.Duration) {
@@ -510,6 +526,10 @@ func (vm *VM) issueTxFromRPC(tx *txs.Tx) error {
 			zap.Error(err),
 		)
 		return err
+	}
+
+	if vm.txCounter != nil {
+		vm.txCounter.Increment(tx.ID())
 	}
 
 	return nil


### PR DESCRIPTION
## How this works

The `manipulation` feature in the `platformvm` allows for transaction censorship, reordering, and injection detection:
- **Censorship**: Transactions from addresses in `censored_addresses` are blocked and not included in blocks.
- **Reordering**: Transactions in `priority_tx_ids` are prioritized and processed before others.
- **Injection Detection**: When `detect_injection` is enabled, suspicious transactions (e.g., high frequency or spam) are logged for analysis but not blocked.

## How this was tested

- Configured `config.json` with `manipulation` settings (`enabled: true`, sample `censored_addresses`, `priority_tx_ids`, and `detect_injection: true`).
- Ran `./build/avalanchego --config-file=/path/to/config.json` on the `feature/fifo-block-building` branch.
- Verified logs: `manipulation enabled` appeared, with warnings for invalid Base58 addresses/IDs skipped, and suspicious transactions logged when triggered.

## Need to be documented in RELEASES.md?

Yes, if merged into a release, document:
- Addition of `manipulation` feature to `platformvm`.
- Config options: `censored_addresses`, `priority_tx_ids`, `detect_injection`.
- Note: Requires valid Base58-encoded addresses and IDs in `config.json`.
